### PR TITLE
Relax validation paths skip

### DIFF
--- a/src/dandi_compute_code/aind_ephys_pipeline/submission_template.txt
+++ b/src/dandi_compute_code/aind_ephys_pipeline/submission_template.txt
@@ -41,5 +41,5 @@ mv nextflow/* ../logs/
 cd ..
 rm -rf $RESULTS_PATH  # Clean up intermediate values
 
-dandi upload --allow-any-path --validation skip  # TODO: remove need for extra flags
+dandi upload --validation skip  # Dandiset is valid if ignoring NWBI issues from copied files (BIDS part is valid)
 echo "{{ temp_name }}" >> {{ done_tracker_file_path }}


### PR DESCRIPTION
Don't need this any more

Technically we will always need to ignore validation errors at NWBI level since we can't guarantee previously uploaded files are still valid to 'latest' requirements