### PR TITLE
Refactor _submit_next to use datalad_directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.9"
+version = "0.3.10"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.8"
+version = "0.3.9"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/_cli/_dandicompute_group.py
+++ b/src/dandi_compute_code/_cli/_dandicompute_group.py
@@ -339,13 +339,26 @@ def _queue_stats_command(
     required=True,
     type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
 )
+@click.option(
+    "--datalad",
+    "datalad_directory",
+    help="Path to the DataLad-backed work tree used to resolve attempt directories (defaults to --dandiset).",
+    required=False,
+    type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
+    default=None,
+)
 def _queue_process_command(
     queue_directory: pathlib.Path,
     dandiset_directory: pathlib.Path,
+    datalad_directory: pathlib.Path | None,
 ) -> None:
     """Submit queued jobs when no active dandicompute jobs are running."""
     _require_dandi_api_key()
-    process_queue(queue_directory=queue_directory, dandiset_directory=dandiset_directory)
+    process_queue(
+        queue_directory=queue_directory,
+        dandiset_directory=dandiset_directory,
+        datalad_directory=datalad_directory,
+    )
 
 
 # dandicompute queue prepare [OPTIONS]

--- a/src/dandi_compute_code/_cli/_dandicompute_group.py
+++ b/src/dandi_compute_code/_cli/_dandicompute_group.py
@@ -342,15 +342,14 @@ def _queue_stats_command(
 @click.option(
     "--datalad",
     "datalad_directory",
-    help="Path to the DataLad-backed work tree used to resolve attempt directories (defaults to --dandiset).",
-    required=False,
+    help="Path to the DataLad-backed work tree used to resolve attempt directories.",
+    required=True,
     type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
-    default=None,
 )
 def _queue_process_command(
     queue_directory: pathlib.Path,
     dandiset_directory: pathlib.Path,
-    datalad_directory: pathlib.Path | None,
+    datalad_directory: pathlib.Path,
 ) -> None:
     """Submit queued jobs when no active dandicompute jobs are running."""
     _require_dandi_api_key()

--- a/src/dandi_compute_code/aind_ephys_pipeline/_submit_job.py
+++ b/src/dandi_compute_code/aind_ephys_pipeline/_submit_job.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import subprocess
+import warnings
 
 import pydantic
 
@@ -13,6 +14,7 @@ def submit_job(script_file_path: pathlib.Path) -> None:
         raise RuntimeError(message)
 
     command = ["sbatch", str(script_file_path)]
+    warnings.warn(f"Submitting sbatch script: {script_file_path}", stacklevel=2)
     result = subprocess.run(
         command,
         capture_output=True,

--- a/src/dandi_compute_code/queue/_clean_unsubmitted_capsules.py
+++ b/src/dandi_compute_code/queue/_clean_unsubmitted_capsules.py
@@ -20,7 +20,7 @@ def clean_unsubmitted_capsules(
     A capsule is considered *queued* (prepared but not yet submitted) when its
     attempt directory has a ``code/`` subdirectory but neither a non-empty
     ``logs/`` subdirectory nor a ``derivatives/`` subdirectory, and the attempt
-    directory does not contain a ``code/.submitted`` marker.
+    directory does not contain a ``code/submitted`` marker.
 
     The function scans *dandiset_directory* for all attempt directories using
     the local filesystem as the ground truth, filters to the queued subset,

--- a/src/dandi_compute_code/queue/_process_queue.py
+++ b/src/dandi_compute_code/queue/_process_queue.py
@@ -11,7 +11,7 @@ def process_queue(
     *,
     queue_directory: pathlib.Path,
     dandiset_directory: pathlib.Path,
-    datalad_directory: pathlib.Path | None = None,
+    datalad_directory: pathlib.Path,
 ) -> None:
     """
     Submit jobs from ``state.jsonl`` up to two total
@@ -36,9 +36,8 @@ def process_queue(
         Path to a local clone of the 001697 dandiset repository.  Used to
         locate prepared submission scripts and to count failure directories
         for ``max_fail_per_dandiset`` enforcement.
-    datalad_directory : pathlib.Path | None, optional
-        Path to the DataLad-backed work tree used to resolve attempt
-        directories. Defaults to ``dandiset_directory``.
+    datalad_directory : pathlib.Path
+        Path to the DataLad-backed Dandiset used to resolve attempt directories.
 
     Raises
     ------
@@ -65,10 +64,9 @@ def process_queue(
         running_count = _count_running_aind_ephys_pipeline_jobs()
         available_slots = max(0, 2 - running_count)
         if available_slots > 0:
-            datalad_root = datalad_directory if datalad_directory is not None else dandiset_directory
             _submit_next(
                 queue_directory=queue_directory,
-                datalad_directory=datalad_root,
+                datalad_directory=datalad_directory,
                 dandiset_directory=dandiset_directory,
                 max_submissions=available_slots,
             )

--- a/src/dandi_compute_code/queue/_process_queue.py
+++ b/src/dandi_compute_code/queue/_process_queue.py
@@ -7,7 +7,12 @@ from ._submit_next import _submit_next
 
 
 # TODO: remove inherent flock usage and offload that to `flock` in CLI submitter
-def process_queue(*, queue_directory: pathlib.Path, dandiset_directory: pathlib.Path) -> None:
+def process_queue(
+    *,
+    queue_directory: pathlib.Path,
+    dandiset_directory: pathlib.Path,
+    datalad_directory: pathlib.Path | None = None,
+) -> None:
     """
     Submit jobs from ``state.jsonl`` up to two total
     running ``AIND-Ephys-Pipeline`` SLURM jobs.
@@ -31,6 +36,9 @@ def process_queue(*, queue_directory: pathlib.Path, dandiset_directory: pathlib.
         Path to a local clone of the 001697 dandiset repository.  Used to
         locate prepared submission scripts and to count failure directories
         for ``max_fail_per_dandiset`` enforcement.
+    datalad_directory : pathlib.Path | None, optional
+        Path to the DataLad-backed work tree used to resolve attempt
+        directories. Defaults to ``dandiset_directory``.
 
     Raises
     ------
@@ -57,8 +65,10 @@ def process_queue(*, queue_directory: pathlib.Path, dandiset_directory: pathlib.
         running_count = _count_running_aind_ephys_pipeline_jobs()
         available_slots = max(0, 2 - running_count)
         if available_slots > 0:
+            datalad_root = datalad_directory if datalad_directory is not None else dandiset_directory
             _submit_next(
                 queue_directory=queue_directory,
+                datalad_directory=datalad_root,
                 dandiset_directory=dandiset_directory,
                 max_submissions=available_slots,
             )

--- a/src/dandi_compute_code/queue/_resolve_unsubmitted_attempt_dir.py
+++ b/src/dandi_compute_code/queue/_resolve_unsubmitted_attempt_dir.py
@@ -9,7 +9,7 @@ def _resolve_unsubmitted_attempt_dir(*, base_dir: pathlib.Path, entry: dict) -> 
         return None
 
     attempt_dir = _resolve_attempt_dir(base_dir=base_dir, entry=entry)
-    submitted_marker = attempt_dir / "code" / ".submitted"
+    submitted_marker = attempt_dir / "code" / "submitted"
     if submitted_marker.exists():
         return None
     return attempt_dir

--- a/src/dandi_compute_code/queue/_submit_next.py
+++ b/src/dandi_compute_code/queue/_submit_next.py
@@ -74,7 +74,7 @@ def _submit_next(
         attempt_dir_relative_to_dandiset = dandiset_directory / attempt_dir_relative_to_datalad
         submitted_marker = attempt_dir_relative_to_dandiset / "code" / "submitted"
         if not submitted_marker.parent.exists():
-            message = f"Creating '{submitted_marker.parent.absolute()}'\n"  # TODO: could be replaced with logging.info
+            message = f"Creating '{submitted_marker.parent.absolute()}'"  # TODO: could be replaced with logging.info
             warnings.warn(message=message, stacklevel=2)
             submitted_marker.parent.mkdir(parents=True, exist_ok=True)
         submitted_marker.write_bytes(b"1")

--- a/src/dandi_compute_code/queue/_submit_next.py
+++ b/src/dandi_compute_code/queue/_submit_next.py
@@ -77,7 +77,7 @@ def _submit_next(
             message = f"Creating '{submitted_marker.parent.absolute()}'\n"  # TODO: could be replaced with logging.info
             warnings.warn(message=message, stacklevel=2)
             submitted_marker.parent.mkdir(parents=True, exist_ok=True)
-        submitted_marker.touch()
+        submitted_marker.write_bytes(b"1")
         submitted_count += 1
         if submitted_count >= max_submissions:
             break

--- a/src/dandi_compute_code/queue/_submit_next.py
+++ b/src/dandi_compute_code/queue/_submit_next.py
@@ -30,9 +30,12 @@ def _submit_next(
     ----------
     queue_directory : pathlib.Path
         Path to the queue root directory.
+    datalad_directory : pathlib.Path
+        Path to the DataLad-backed work tree used to resolve unsubmitted
+        attempt directories.
     dandiset_directory : pathlib.Path
         Path to a local clone of the 001697 dandiset repository.  Used to
-        locate prepared submission scripts.
+        write submission marker files after backend submission.
     max_submissions : int, optional
         Maximum number of pending jobs to submit from the ordered queue.
 

--- a/src/dandi_compute_code/queue/_submit_next.py
+++ b/src/dandi_compute_code/queue/_submit_next.py
@@ -69,16 +69,14 @@ def _submit_next(
 
         submit_job(script_file_path=script_file_path)
 
-        # Actual submit marks must go to DANDI backend first
+        # Actual submission marks must go to DANDI backend first
         attempt_dir_relative_to_datalad = attempt_dir.relative_to(datalad_directory)
         attempt_dir_relative_to_dandiset = dandiset_directory / attempt_dir_relative_to_datalad
         submitted_marker = attempt_dir_relative_to_dandiset / "code" / ".submitted"
         if not submitted_marker.parent.exists():
-            message = (
-                f"Local Dandiset shell did not find parents of submission marker.\nCreating for {submitted_marker}"
-            )
+            message = f"Creating '{submitted_marker.parent.absolute()}'\n"  # TODO: could be replaced with logging.info
             warnings.warn(message=message, stacklevel=2)
-            submitted_marker.parent.mkdir(parents=True, exist_ok=True)  # Likely required on real Dandiset shell
+            submitted_marker.parent.mkdir(parents=True, exist_ok=True)
         submitted_marker.touch()
         submitted_count += 1
         if submitted_count >= max_submissions:

--- a/src/dandi_compute_code/queue/_submit_next.py
+++ b/src/dandi_compute_code/queue/_submit_next.py
@@ -10,6 +10,7 @@ from ..aind_ephys_pipeline import submit_job
 def _submit_next(
     *,
     queue_directory: pathlib.Path,
+    datalad_directory: pathlib.Path,
     dandiset_directory: pathlib.Path,
     max_submissions: int = 2,
 ) -> bool:
@@ -53,7 +54,7 @@ def _submit_next(
     pending_attempt_dirs = [
         attempt_dir
         for entry in state_entries
-        if (attempt_dir := _resolve_unsubmitted_attempt_dir(base_dir=dandiset_directory, entry=entry)) is not None
+        if (attempt_dir := _resolve_unsubmitted_attempt_dir(base_dir=datalad_directory, entry=entry)) is not None
     ]
     submitted_count = 0
 
@@ -64,7 +65,11 @@ def _submit_next(
             raise FileNotFoundError(message)
 
         submit_job(script_file_path=script_file_path)
-        submitted_marker = attempt_dir / "code" / ".submitted"
+
+        # Actual submit marks must go to DANDI backend first
+        attempt_dir_relative_to_datalad = attempt_dir.relative_to(datalad_directory)
+        attempt_dir_relative_to_dandiset = dandiset_directory / attempt_dir_relative_to_datalad
+        submitted_marker = attempt_dir_relative_to_dandiset / "code" / ".submitted"
         if not submitted_marker.parent.exists():
             message = (
                 f"Local Dandiset shell did not find parents of submission marker.\nCreating for {submitted_marker}"

--- a/src/dandi_compute_code/queue/_submit_next.py
+++ b/src/dandi_compute_code/queue/_submit_next.py
@@ -23,7 +23,7 @@ def _submit_next(
 
     Entries are filtered to those with no output and no logs. The first up to
     ``max_submissions`` eligible entries that do not already have a
-    ``code/.submitted`` marker are submitted, and each marker is created
+    ``code/submitted`` marker are submitted, and each marker is created
     immediately after submission succeeds.
 
     Parameters
@@ -72,7 +72,7 @@ def _submit_next(
         # Actual submission marks must go to DANDI backend first
         attempt_dir_relative_to_datalad = attempt_dir.relative_to(datalad_directory)
         attempt_dir_relative_to_dandiset = dandiset_directory / attempt_dir_relative_to_datalad
-        submitted_marker = attempt_dir_relative_to_dandiset / "code" / ".submitted"
+        submitted_marker = attempt_dir_relative_to_dandiset / "code" / "submitted"
         if not submitted_marker.parent.exists():
             message = f"Creating '{submitted_marker.parent.absolute()}'\n"  # TODO: could be replaced with logging.info
             warnings.warn(message=message, stacklevel=2)

--- a/tests/test_process_queue.py
+++ b/tests/test_process_queue.py
@@ -1020,7 +1020,11 @@ def test_process_queue_handles_empty_scan_when_waiting_file_missing(tmp_path: pa
     dandiset_dir.mkdir()
 
     with pytest.raises(FileNotFoundError, match="State file not found"):
-        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        process_queue(
+            queue_directory=queue_dir,
+            dandiset_directory=dandiset_dir,
+            datalad_directory=dandiset_dir,
+        )
 
 
 @pytest.mark.ai_generated
@@ -1036,7 +1040,11 @@ def test_process_queue_refreshes_state_when_empty(tmp_path: pathlib.Path) -> Non
         mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs", return_value=2),
         mock.patch("dandi_compute_code.queue._process_queue._submit_next") as mock_submit,
     ):
-        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        process_queue(
+            queue_directory=queue_dir,
+            dandiset_directory=dandiset_dir,
+            datalad_directory=dandiset_dir,
+        )
 
     mock_submit.assert_not_called()
 
@@ -1054,7 +1062,11 @@ def test_process_queue_skips_refresh_when_state_non_empty(tmp_path: pathlib.Path
         mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs", return_value=2),
         mock.patch("dandi_compute_code.queue._process_queue._submit_next") as mock_submit,
     ):
-        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        process_queue(
+            queue_directory=queue_dir,
+            dandiset_directory=dandiset_dir,
+            datalad_directory=dandiset_dir,
+        )
 
     mock_submit.assert_not_called()
 
@@ -1076,7 +1088,11 @@ def test_process_queue_skips_when_lock_is_already_held(
         mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs") as mock_running,
         mock.patch("dandi_compute_code.queue._process_queue._submit_next") as mock_submit,
     ):
-        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        process_queue(
+            queue_directory=queue_dir,
+            dandiset_directory=dandiset_dir,
+            datalad_directory=dandiset_dir,
+        )
 
     captured = capsys.readouterr()
     assert "Skipping queue processing: lock already held" in captured.out
@@ -1096,7 +1112,11 @@ def test_process_queue_submits_when_no_jobs_running(tmp_path: pathlib.Path) -> N
         mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs", return_value=0),
         mock.patch("dandi_compute_code.queue._process_queue._submit_next", return_value=True) as mock_submit,
     ):
-        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        process_queue(
+            queue_directory=queue_dir,
+            dandiset_directory=dandiset_dir,
+            datalad_directory=dandiset_dir,
+        )
 
     mock_submit.assert_called_once_with(
         queue_directory=queue_dir,
@@ -1118,7 +1138,11 @@ def test_process_queue_does_not_submit_when_jobs_running(tmp_path: pathlib.Path)
         mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs", return_value=2),
         mock.patch("dandi_compute_code.queue._process_queue._submit_next") as mock_submit,
     ):
-        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        process_queue(
+            queue_directory=queue_dir,
+            dandiset_directory=dandiset_dir,
+            datalad_directory=dandiset_dir,
+        )
 
     mock_submit.assert_not_called()
 
@@ -1135,7 +1159,11 @@ def test_process_queue_submits_one_when_one_job_running(tmp_path: pathlib.Path) 
         mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs", return_value=1),
         mock.patch("dandi_compute_code.queue._process_queue._submit_next", return_value=True) as mock_submit,
     ):
-        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        process_queue(
+            queue_directory=queue_dir,
+            dandiset_directory=dandiset_dir,
+            datalad_directory=dandiset_dir,
+        )
 
     mock_submit.assert_called_once_with(
         queue_directory=queue_dir,
@@ -1146,8 +1174,10 @@ def test_process_queue_submits_one_when_one_job_running(tmp_path: pathlib.Path) 
 
 
 @pytest.mark.ai_generated
-def test_process_queue_passes_dandiset_directory_to_submit_next(tmp_path: pathlib.Path) -> None:
-    """process_queue forwards dandiset_directory to _submit_next when idle."""
+def test_process_queue_passes_datalad_directory_to_submit_next_when_matching_dandiset(
+    tmp_path: pathlib.Path,
+) -> None:
+    """process_queue forwards datalad_directory to _submit_next when idle."""
     queue_dir = _make_queue_dir(tmp_path)
     _write_jsonl(queue_dir / "state.jsonl", [_make_state_entry()])
     dandiset_dir = tmp_path / "001697"
@@ -1157,7 +1187,11 @@ def test_process_queue_passes_dandiset_directory_to_submit_next(tmp_path: pathli
         mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs", return_value=0),
         mock.patch("dandi_compute_code.queue._process_queue._submit_next", return_value=True) as mock_submit,
     ):
-        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        process_queue(
+            queue_directory=queue_dir,
+            dandiset_directory=dandiset_dir,
+            datalad_directory=dandiset_dir,
+        )
 
     mock_submit.assert_called_once_with(
         queue_directory=queue_dir,

--- a/tests/test_process_queue.py
+++ b/tests/test_process_queue.py
@@ -581,7 +581,7 @@ def test_submit_next_warns_and_returns_false_when_state_file_is_empty(tmp_path: 
 
 @pytest.mark.ai_generated
 def test_submit_next_returns_false_when_no_eligible_entries(tmp_path: pathlib.Path) -> None:
-    """_submit_next returns False when all ordered entries already have .submitted markers."""
+    """_submit_next returns False when all ordered entries already have submitted markers."""
     queue_dir = _make_queue_dir(tmp_path)
     dandiset_dir = tmp_path / "dandiset"
 
@@ -608,8 +608,8 @@ def test_submit_next_returns_false_when_no_eligible_entries(tmp_path: pathlib.Pa
         config="abc123",
         attempt=1,
     )
-    (first_attempt_dir / "code" / ".submitted").touch()
-    (second_attempt_dir / "code" / ".submitted").touch()
+    (first_attempt_dir / "code" / "submitted").touch()
+    (second_attempt_dir / "code" / "submitted").touch()
 
     with (
         pytest.warns(UserWarning, match="No eligible pending entries available for submission"),
@@ -807,7 +807,7 @@ def test_submit_next_leaves_state_jsonl_unchanged_after_submission(tmp_path: pat
 
 @pytest.mark.ai_generated
 def test_submit_next_creates_submitted_marker_file(tmp_path: pathlib.Path) -> None:
-    """_submit_next creates a .submitted marker next to code/submit.sh."""
+    """_submit_next creates a submitted marker next to code/submit.sh."""
     queue_dir = _make_queue_dir(tmp_path)
     dandiset_dir = tmp_path / "dandiset"
 
@@ -835,7 +835,7 @@ def test_submit_next_creates_submitted_marker_file(tmp_path: pathlib.Path) -> No
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job"):
         _submit_next(queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir)
 
-    assert (attempt_dir / "code" / ".submitted").exists()
+    assert (attempt_dir / "code" / "submitted").exists()
 
 
 @pytest.mark.ai_generated
@@ -911,14 +911,14 @@ def test_submit_next_submits_top_two_eligible_entries(tmp_path: pathlib.Path) ->
         mock.call(script_file_path=first_attempt_dir / "code" / "submit.sh"),
         mock.call(script_file_path=second_attempt_dir / "code" / "submit.sh"),
     ]
-    assert (first_attempt_dir / "code" / ".submitted").exists()
-    assert (second_attempt_dir / "code" / ".submitted").exists()
-    assert not (third_attempt_dir / "code" / ".submitted").exists()
+    assert (first_attempt_dir / "code" / "submitted").exists()
+    assert (second_attempt_dir / "code" / "submitted").exists()
+    assert not (third_attempt_dir / "code" / "submitted").exists()
 
 
 @pytest.mark.ai_generated
 def test_submit_next_submits_next_entry_when_first_has_submitted_marker(tmp_path: pathlib.Path) -> None:
-    """_submit_next skips entries with code/.submitted markers and submits the next one."""
+    """_submit_next skips entries with code/submitted markers and submits the next one."""
     queue_dir = _make_queue_dir(tmp_path)
     dandiset_dir = tmp_path / "dandiset"
     first_entry = _make_state_entry(dandiset_id="000001")
@@ -935,7 +935,7 @@ def test_submit_next_submits_next_entry_when_first_has_submitted_marker(tmp_path
         config="abc123",
         attempt=1,
     )
-    (first_attempt_dir / "code" / ".submitted").touch()
+    (first_attempt_dir / "code" / "submitted").touch()
     second_attempt_dir = _make_attempt_dir_with_script(
         dandiset_dir,
         dandiset_id="000002",
@@ -1352,7 +1352,7 @@ def test_refresh_queue_state_excludes_entries_with_submitted_markers(tmp_path: p
         config="abc123",
         attempt=1,
     )
-    (submitted_attempt_dir / "code" / ".submitted").touch()
+    (submitted_attempt_dir / "code" / "submitted").touch()
 
     with mock.patch(
         "dandi_compute_code.queue._refresh_queue.scan_dandiset_directory",
@@ -2233,7 +2233,7 @@ def test_clean_unsubmitted_capsules_ignores_dataset_description_in_logs(
 
 @pytest.mark.ai_generated
 def test_clean_unsubmitted_capsules_skips_entries_with_submitted_marker(tmp_path: pathlib.Path) -> None:
-    """clean_unsubmitted_capsules does not remove capsules with a code/.submitted marker."""
+    """clean_unsubmitted_capsules does not remove capsules with a code/submitted marker."""
     dandiset_dir = tmp_path / "dandiset"
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
@@ -2242,7 +2242,7 @@ def test_clean_unsubmitted_capsules_skips_entries_with_submitted_marker(tmp_path
         dandiset_dir, "000001", "mouse01", "aind+ephys", "v1.0", "abc1234", "def5678", 1, with_code=True
     )
 
-    (queued_dir / "code" / ".submitted").touch()
+    (queued_dir / "code" / "submitted").touch()
 
     with mock.patch("subprocess.run") as mock_run, mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}):
         removed = clean_unsubmitted_capsules(dandiset_directory=dandiset_dir, queue_directory=queue_dir)
@@ -2402,7 +2402,7 @@ def test_clean_unsubmitted_capsules_removes_only_queued_not_submitted(tmp_path: 
     submitted_dir = _make_full_attempt_dir(
         dandiset_dir, "000002", "mouse02", "aind+ephys", "v1.0", "abc1234", "def5678", 1, with_code=True
     )
-    (submitted_dir / "code" / ".submitted").touch()
+    (submitted_dir / "code" / "submitted").touch()
 
     with mock.patch("subprocess.run"), mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}):
         removed = clean_unsubmitted_capsules(dandiset_directory=dandiset_dir, queue_directory=queue_dir)

--- a/tests/test_process_queue.py
+++ b/tests/test_process_queue.py
@@ -551,14 +551,19 @@ def test_submit_next_raises_when_state_file_is_absent(tmp_path: pathlib.Path) ->
     queue_dir = _make_queue_dir(tmp_path)
 
     with pytest.raises(FileNotFoundError, match="State file not found"):
-        _submit_next(queue_directory=queue_dir, dandiset_directory=tmp_path)
+        _submit_next(queue_directory=queue_dir, datalad_directory=tmp_path, dandiset_directory=tmp_path)
 
 
 @pytest.mark.ai_generated
 def test_submit_next_returns_false_when_max_submissions_less_than_one(tmp_path: pathlib.Path) -> None:
     """_submit_next returns False for invalid max_submissions before reading state.jsonl."""
     queue_dir = _make_queue_dir(tmp_path)
-    result = _submit_next(queue_directory=queue_dir, dandiset_directory=tmp_path, max_submissions=0)
+    result = _submit_next(
+        queue_directory=queue_dir,
+        datalad_directory=tmp_path,
+        dandiset_directory=tmp_path,
+        max_submissions=0,
+    )
     assert result is False
 
 
@@ -569,7 +574,7 @@ def test_submit_next_warns_and_returns_false_when_state_file_is_empty(tmp_path: 
     (queue_dir / "state.jsonl").write_text("")
 
     with pytest.warns(UserWarning, match="No pending entries in"):
-        result = _submit_next(queue_directory=queue_dir, dandiset_directory=tmp_path)
+        result = _submit_next(queue_directory=queue_dir, datalad_directory=tmp_path, dandiset_directory=tmp_path)
 
     assert result is False
 
@@ -610,7 +615,9 @@ def test_submit_next_returns_false_when_no_eligible_entries(tmp_path: pathlib.Pa
         pytest.warns(UserWarning, match="No eligible pending entries available for submission"),
         mock.patch("dandi_compute_code.queue._submit_next.submit_job") as mock_submit,
     ):
-        result = _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        result = _submit_next(
+            queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir
+        )
 
     assert result is False
     mock_submit.assert_not_called()
@@ -645,7 +652,9 @@ def test_submit_next_submits_first_pending_entry_in_state_order(tmp_path: pathli
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job") as mock_submit:
-        result = _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        result = _submit_next(
+            queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir
+        )
 
     assert result is True
     mock_submit.assert_called_once()
@@ -664,7 +673,7 @@ def test_submit_next_raised_when_script_missing(tmp_path: pathlib.Path) -> None:
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job"):
         with pytest.raises(FileNotFoundError, match="Submit script not found:"):
-            _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+            _submit_next(queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir)
 
 
 @pytest.mark.ai_generated
@@ -695,7 +704,9 @@ def test_submit_next_found_flat_attempt_directory_under_scanned_dandi_path(tmp_p
     script_file_path.write_text("#!/bin/bash\necho hello\n")
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job") as mock_submit:
-        result = _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        result = _submit_next(
+            queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir
+        )
 
     assert result is True
     mock_submit.assert_called_once_with(script_file_path=script_file_path)
@@ -732,7 +743,9 @@ def test_submit_next_uses_session_in_path_when_present(tmp_path: pathlib.Path) -
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job") as mock_submit:
-        result = _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        result = _submit_next(
+            queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir
+        )
 
     assert result is True
     assert mock_submit.called
@@ -786,7 +799,7 @@ def test_submit_next_leaves_state_jsonl_unchanged_after_submission(tmp_path: pat
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job"):
-        _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        _submit_next(queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir)
 
     remaining = _read_jsonl(queue_dir / "state.jsonl")
     assert remaining == [entry1, entry2]
@@ -820,7 +833,7 @@ def test_submit_next_creates_submitted_marker_file(tmp_path: pathlib.Path) -> No
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job"):
-        _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        _submit_next(queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir)
 
     assert (attempt_dir / "code" / ".submitted").exists()
 
@@ -891,7 +904,7 @@ def test_submit_next_submits_top_two_eligible_entries(tmp_path: pathlib.Path) ->
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job") as mock_submit:
-        _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        _submit_next(queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir)
 
     assert mock_submit.call_count == 2
     assert mock_submit.call_args_list == [
@@ -935,7 +948,11 @@ def test_submit_next_submits_next_entry_when_first_has_submitted_marker(tmp_path
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job") as mock_submit:
-        submitted = _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        submitted = _submit_next(
+            queue_directory=queue_dir,
+            datalad_directory=dandiset_dir,
+            dandiset_directory=dandiset_dir,
+        )
 
     assert submitted is True
     mock_submit.assert_called_once_with(script_file_path=second_attempt_dir / "code" / "submit.sh")
@@ -977,7 +994,11 @@ def test_submit_next_only_submits_entries_pending_in_state_jsonl(tmp_path: pathl
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job") as mock_submit:
-        submitted = _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        submitted = _submit_next(
+            queue_directory=queue_dir,
+            datalad_directory=dandiset_dir,
+            dandiset_directory=dandiset_dir,
+        )
 
     assert submitted is True
     mock_submit.assert_called_once_with(script_file_path=eligible_attempt_dir / "code" / "submit.sh")
@@ -1079,6 +1100,7 @@ def test_process_queue_submits_when_no_jobs_running(tmp_path: pathlib.Path) -> N
 
     mock_submit.assert_called_once_with(
         queue_directory=queue_dir,
+        datalad_directory=dandiset_dir,
         dandiset_directory=dandiset_dir,
         max_submissions=2,
     )
@@ -1117,6 +1139,7 @@ def test_process_queue_submits_one_when_one_job_running(tmp_path: pathlib.Path) 
 
     mock_submit.assert_called_once_with(
         queue_directory=queue_dir,
+        datalad_directory=dandiset_dir,
         dandiset_directory=dandiset_dir,
         max_submissions=1,
     )
@@ -1138,6 +1161,31 @@ def test_process_queue_passes_dandiset_directory_to_submit_next(tmp_path: pathli
 
     mock_submit.assert_called_once_with(
         queue_directory=queue_dir,
+        datalad_directory=dandiset_dir,
+        dandiset_directory=dandiset_dir,
+        max_submissions=2,
+    )
+
+
+@pytest.mark.ai_generated
+def test_process_queue_passes_datalad_directory_to_submit_next(tmp_path: pathlib.Path) -> None:
+    """process_queue forwards explicit datalad_directory to _submit_next when idle."""
+    queue_dir = _make_queue_dir(tmp_path)
+    _write_jsonl(queue_dir / "state.jsonl", [_make_state_entry()])
+    dandiset_dir = tmp_path / "001697"
+    dandiset_dir.mkdir()
+    datalad_dir = tmp_path / "datalad"
+    datalad_dir.mkdir()
+
+    with (
+        mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs", return_value=0),
+        mock.patch("dandi_compute_code.queue._process_queue._submit_next", return_value=True) as mock_submit,
+    ):
+        process_queue(queue_directory=queue_dir, dandiset_directory=dandiset_dir, datalad_directory=datalad_dir)
+
+    mock_submit.assert_called_once_with(
+        queue_directory=queue_dir,
+        datalad_directory=datalad_dir,
         dandiset_directory=dandiset_dir,
         max_submissions=2,
     )
@@ -1589,7 +1637,12 @@ def test_submit_next_submits_first_entry_directly(tmp_path: pathlib.Path) -> Non
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job"):
-        result = _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir, max_submissions=1)
+        result = _submit_next(
+            queue_directory=queue_dir,
+            datalad_directory=dandiset_dir,
+            dandiset_directory=dandiset_dir,
+            max_submissions=1,
+        )
 
     assert result is True
 
@@ -1627,7 +1680,9 @@ def test_submit_next_submits_first_entry_with_existing_failure_dirs(tmp_path: pa
     )
 
     with mock.patch("dandi_compute_code.queue._submit_next.submit_job"):
-        result = _submit_next(queue_directory=queue_dir, dandiset_directory=dandiset_dir)
+        result = _submit_next(
+            queue_directory=queue_dir, datalad_directory=dandiset_dir, dandiset_directory=dandiset_dir
+        )
 
     assert result is True
 
@@ -2542,6 +2597,40 @@ def test_cli_queue_prepare_required_queue_directory() -> None:
         result = runner.invoke(_dandicompute_group, ["queue", "prepare"])
     assert result.exit_code != 0
     assert "Missing option '--queue'" in result.output
+
+
+@pytest.mark.ai_generated
+def test_cli_queue_process_passes_explicit_datalad_directory(tmp_path: pathlib.Path) -> None:
+    """dandicompute queue process forwards --datalad to process_queue."""
+    queue_dir = _make_queue_dir(tmp_path)
+    dandiset_dir = tmp_path / "dandiset"
+    dandiset_dir.mkdir()
+    datalad_dir = tmp_path / "datalad"
+    datalad_dir.mkdir()
+    runner = CliRunner()
+
+    with mock.patch("dandi_compute_code._cli._dandicompute_group.process_queue") as mock_process:
+        result = runner.invoke(
+            _dandicompute_group,
+            [
+                "queue",
+                "process",
+                "--queue",
+                str(queue_dir),
+                "--dandiset",
+                str(dandiset_dir),
+                "--datalad",
+                str(datalad_dir),
+            ],
+            env={"DANDI_API_KEY": "test-key"},
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_process.assert_called_once_with(
+        queue_directory=queue_dir,
+        dandiset_directory=dandiset_dir,
+        datalad_directory=datalad_dir,
+    )
 
 
 @pytest.mark.ai_generated

--- a/tests/test_process_queue.py
+++ b/tests/test_process_queue.py
@@ -2600,6 +2600,22 @@ def test_cli_queue_prepare_required_queue_directory() -> None:
 
 
 @pytest.mark.ai_generated
+def test_cli_queue_process_requires_datalad_directory(tmp_path: pathlib.Path) -> None:
+    """Queue process command requires --datalad."""
+    queue_dir = _make_queue_dir(tmp_path)
+    dandiset_dir = tmp_path / "dandiset"
+    dandiset_dir.mkdir()
+    runner = CliRunner()
+    with mock.patch.dict("os.environ", {"DANDI_API_KEY": "test-key"}):
+        result = runner.invoke(
+            _dandicompute_group,
+            ["queue", "process", "--queue", str(queue_dir), "--dandiset", str(dandiset_dir)],
+        )
+    assert result.exit_code != 0
+    assert "Missing option '--datalad'" in result.output
+
+
+@pytest.mark.ai_generated
 def test_cli_queue_process_passes_explicit_datalad_directory(tmp_path: pathlib.Path) -> None:
     """dandicompute queue process forwards --datalad to process_queue."""
     queue_dir = _make_queue_dir(tmp_path)
@@ -2644,10 +2660,21 @@ def test_cli_queue_process_failed_when_submit_script_missing(tmp_path: pathlib.P
         [_make_state_entry(dandiset_id="000001", pipeline="test", version="v1.0", params="default")],
     )
     runner = CliRunner()
+    datalad_dir = tmp_path / "datalad"
+    datalad_dir.mkdir()
     with mock.patch("dandi_compute_code.queue._process_queue._count_running_aind_ephys_pipeline_jobs", return_value=0):
         result = runner.invoke(
             _dandicompute_group,
-            ["queue", "process", "--queue", str(queue_dir), "--dandiset", str(dandiset_dir)],
+            [
+                "queue",
+                "process",
+                "--queue",
+                str(queue_dir),
+                "--dandiset",
+                str(dandiset_dir),
+                "--datalad",
+                str(datalad_dir),
+            ],
             env={"DANDI_API_KEY": "test-key"},
         )
 

--- a/tests/test_scan_dandiset.py
+++ b/tests/test_scan_dandiset.py
@@ -1270,7 +1270,7 @@ def test_refresh_queue_state_with_dandiset_directory_excludes_entries_with_submi
         1,
         with_code=True,
     )
-    (submitted_attempt_dir / "code" / ".submitted").touch()
+    (submitted_attempt_dir / "code" / "submitted").touch()
 
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()

--- a/tests/test_submit_job.py
+++ b/tests/test_submit_job.py
@@ -1,0 +1,44 @@
+import pathlib
+import re
+from unittest import mock
+
+import pytest
+
+from dandi_compute_code.aind_ephys_pipeline import submit_job
+
+
+@pytest.mark.ai_generated
+def test_submit_job_warns_with_sbatch_script_path(tmp_path: pathlib.Path) -> None:
+    script_file_path = tmp_path / "submit.sh"
+    script_file_path.write_text("#!/usr/bin/env bash\n")
+
+    completed_process = mock.Mock(
+        returncode=0,
+        stdout="Submitted batch job 123\n",
+        stderr="",
+    )
+
+    with (
+        mock.patch.dict("os.environ", {"DANDI_API_KEY": "fake-key"}, clear=True),
+        mock.patch("subprocess.run", return_value=completed_process) as mock_run,
+        pytest.warns(UserWarning, match=re.escape(f"Submitting sbatch script: {script_file_path}")),
+    ):
+        submit_job(script_file_path=script_file_path)
+
+    mock_run.assert_called_once_with(
+        ["sbatch", str(script_file_path)],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.ai_generated
+def test_submit_job_raises_when_dandi_api_key_missing(tmp_path: pathlib.Path) -> None:
+    script_file_path = tmp_path / "submit.sh"
+    script_file_path.write_text("#!/usr/bin/env bash\n")
+
+    with (
+        mock.patch.dict("os.environ", {}, clear=True),
+        pytest.raises(RuntimeError, match="`DANDI_API_KEY` environment variable is not set"),
+    ):
+        submit_job(script_file_path=script_file_path)


### PR DESCRIPTION
Updated the _submit_next function to use datalad_directory for resolving unsubmitted attempt directories and adjusted the path for the submission marker accordingly.