### PR TITLE
Change OS list to 'ubuntu-latest' for daily tests

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -13,7 +13,7 @@ jobs:
   DailyTests:
     uses: ./.github/workflows/testing.yml
     with:
-      os_list: '["windows-2022","windows-latest","macos-15-intel","macos-latest","ubuntu-latest"]'
+      os_list: '["ubuntu-latest"]'
       python_list: '["3.10","3.11","3.12","3.13","3.14"]'
 
   NotifyOnFailure:


### PR DESCRIPTION
Updated the OS list for daily tests to only use 'ubuntu-latest'.