### PR TITLE
Use absolute path for pipeline_repo_directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.29"
+version = "0.3.30"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/aind_ephys_pipeline/_prepare_job.py
+++ b/src/dandi_compute_code/aind_ephys_pipeline/_prepare_job.py
@@ -372,7 +372,7 @@ def prepare_aind_ephys_job(
         environment_directory=environment_directory,
         config_file_path=str(code_config_file_path),
         pipeline_file_path=str(pipeline_file_path),
-        pipeline_repo_directory=str(pipeline_repo_directory),
+        pipeline_repo_directory=str(pipeline_repo_directory.absolute()),
         pipeline_version=pipeline_version,
         temp_name=temporary_processing_directory.name,
         done_tracker_file_path=str(done_tracker_file_path),


### PR DESCRIPTION
Doesn't seem to have been doing harm yet, but caught this in some of the logs