### PR TITLE
Add queue pending command to check for awaiting jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ To clean unsubmitted job capsules:
 dandicompute queue clean --queue ./queue/ --dandiset ./dandi/001697/
 ```
 
+To check whether there is any queued work before dispatching, use `queue pending`. It exits with code 0 when at least one job is awaiting submission, and code 1 when there is nothing to process. This lets a crontab skip the dispatch entirely when the queue is empty:
+
+```bash
+dandicompute queue pending --silent && dandicompute queue process --queue ./queue/ --processing ./processing/
+```
+
 
 
 ## Contributing Non-Code Files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.34"
+version = "0.3.35"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/_cli/_dandicompute_group.py
+++ b/src/dandi_compute_code/_cli/_dandicompute_group.py
@@ -17,6 +17,7 @@ from ..queue import (
     aggregate_queue_statistics,
     clean_unsubmitted_capsules,
     dump_issues,
+    has_pending_jobs,
     prepare_queue,
     process_queue,
     summarize_issues,
@@ -387,6 +388,32 @@ def _queue_stats_command(
         _styled_echo(text=f"\nWrote queue aggregate statistics: {queue_directory / output_file_name}", color="green")
 
 
+# dandicompute queue pending [OPTIONS]
+@_queue_group.command(name="pending")
+@click.option(
+    "--silent",
+    help="Suppress informational log output and the printed result.",
+    required=False,
+    is_flag=True,
+    default=False,
+)
+@click.pass_context
+def _queue_pending_command(context: click.Context, silent: bool = False) -> None:
+    """Report whether any queued jobs are awaiting submission.
+
+    Prints ``true`` and exits with code 0 when at least one job is pending.
+    Prints ``false`` and exits with code 1 when nothing is pending. This lets a
+    crontab skip the dispatch entirely when there is no work, for example:
+
+        dandicompute queue pending --silent && dandicompute queue process ...
+    """
+    _configure_logging(silent=silent)
+    pending = has_pending_jobs()
+    if not silent:
+        _styled_echo(text="true" if pending else "false", color="green" if pending else "yellow")
+    context.exit(0 if pending else 1)
+
+
 # dandicompute queue process [OPTIONS]
 @_queue_group.command(name="process")
 @click.option(
@@ -664,4 +691,5 @@ _dandicompute_group.aggregate_queue_statistics = aggregate_queue_statistics
 _dandicompute_group.dump_issues = dump_issues
 _dandicompute_group.summarize_issues = summarize_issues
 _dandicompute_group.process_queue = process_queue
+_dandicompute_group.has_pending_jobs = has_pending_jobs
 _dandicompute_group.write_queue_state = write_queue_state

--- a/src/dandi_compute_code/queue/__init__.py
+++ b/src/dandi_compute_code/queue/__init__.py
@@ -2,6 +2,7 @@ from ._aggregate_queue_statistics import aggregate_queue_statistics
 from ._clean_unsubmitted_capsules import clean_unsubmitted_capsules
 from ._dump_issues import dump_issues
 from ._globals import TEST_QUEUE_CONTENT_ID
+from ._has_pending_jobs import has_pending_jobs
 from ._prepare_queue import prepare_queue
 from ._process_queue import process_queue
 from ._queue_state import JobEntry, QueueState
@@ -13,6 +14,7 @@ __all__ = [
     "aggregate_queue_statistics",
     "clean_unsubmitted_capsules",
     "dump_issues",
+    "has_pending_jobs",
     "JobEntry",
     "JobInfo",
     "prepare_queue",

--- a/src/dandi_compute_code/queue/_find_pending_entries.py
+++ b/src/dandi_compute_code/queue/_find_pending_entries.py
@@ -1,0 +1,38 @@
+import logging
+
+from ..dandiset._load_assets_jsonld_metadata import load_assets_jsonld_metadata
+
+_log = logging.getLogger(__name__)
+
+
+def _find_pending_entries() -> list[str]:
+    """
+    Identify attempt directories awaiting submission from the DANDI assets metadata.
+
+    Loads the DANDI ``assets.jsonld`` metadata and collects every attempt
+    directory that contains a ``code/submit.sh`` asset but no adjacent
+    submitted-marker asset. An entry is considered submitted when a sibling
+    ``submitted`` asset exists, or when a sibling asset whose name starts with
+    ``submitted_date-`` exists.
+
+    Returns
+    -------
+    list[str]
+        Sorted list of ``code`` directory paths (relative to the Dandiset root)
+        that are pending submission. Empty when nothing is awaiting submission.
+    """
+    metadata = load_assets_jsonld_metadata()
+    paths = set(metadata.path_to_asset_metadata.keys())
+
+    pending_entries: list[str] = []
+    for asset_path in sorted(paths):
+        if asset_path.endswith("/code/submit.sh"):
+            code_dir_path = asset_path[: -len("/submit.sh")]
+            submitted_marker_prefix = f"{code_dir_path}/submitted_date-"
+            has_submitted_marker = any(
+                path == f"{code_dir_path}/submitted" or path.startswith(submitted_marker_prefix) for path in paths
+            )
+            if not has_submitted_marker:
+                pending_entries.append(code_dir_path)
+
+    return pending_entries

--- a/src/dandi_compute_code/queue/_has_pending_jobs.py
+++ b/src/dandi_compute_code/queue/_has_pending_jobs.py
@@ -1,0 +1,25 @@
+import logging
+
+from ._find_pending_entries import _find_pending_entries
+
+_log = logging.getLogger(__name__)
+
+
+def has_pending_jobs() -> bool:
+    """
+    Report whether any queued jobs are awaiting submission.
+
+    This is a lightweight check intended to gate queue dispatch. It inspects the
+    DANDI assets metadata for attempt directories that contain a ``code/submit.sh``
+    asset without an adjacent submitted marker. It does not submit anything and
+    does not require SLURM access.
+
+    Returns
+    -------
+    bool
+        ``True`` when at least one job is awaiting submission, ``False`` otherwise.
+    """
+    pending_entries = _find_pending_entries()
+    pending = len(pending_entries) > 0
+    _log.info("Found %d pending queue entries", len(pending_entries))
+    return pending

--- a/src/dandi_compute_code/queue/_submit_next.py
+++ b/src/dandi_compute_code/queue/_submit_next.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import tempfile
 
-from ..dandiset._load_assets_jsonld_metadata import load_assets_jsonld_metadata
+from ._find_pending_entries import _find_pending_entries
 
 _log = logging.getLogger(__name__)
 
@@ -55,19 +55,7 @@ def _submit_next(
     if max_submissions < 1:
         return False
 
-    metadata = load_assets_jsonld_metadata()
-    paths = set(metadata.path_to_asset_metadata.keys())
-
-    candidates: list[str] = []
-    for asset_path in sorted(paths):
-        if asset_path.endswith("/code/submit.sh"):
-            code_dir_path = asset_path[: -len("/submit.sh")]
-            submitted_marker_prefix = f"{code_dir_path}/submitted_date-"
-            has_submitted_marker = any(
-                path == f"{code_dir_path}/submitted" or path.startswith(submitted_marker_prefix) for path in paths
-            )
-            if not has_submitted_marker:
-                candidates.append(code_dir_path)
+    candidates = _find_pending_entries()
 
     if not candidates:
         _log.info("No eligible pending entries available for submission")

--- a/tests/dandi_compute_code/_cli/test_cli_descriptions.py
+++ b/tests/dandi_compute_code/_cli/test_cli_descriptions.py
@@ -18,6 +18,7 @@ from dandi_compute_code._cli import _dandicompute_group
         (["queue", "refresh", "--help"], "Regenerate state.jsonl from DANDI assets metadata."),
         (["queue", "clean", "--help"], "Delete unsubmitted capsules that are no longer present in the queue."),
         (["queue", "stats", "--help"], "Write aggregate queue statistics from state.jsonl and timeline reports."),
+        (["queue", "pending", "--help"], "Report whether any queued jobs are awaiting submission."),
         (["issues", "--help"], "Scan logs and write per-capsule and aggregate issue reports."),
         (["issues", "dump", "--help"], "Scan nextflow and slurm logs and write per-capsule issue records."),
         (["issues", "summarize", "--help"], "Summarize discovered issue lines by descending occurrence count."),

--- a/tests/dandi_compute_code/queue/test_cli_queue_commands.py
+++ b/tests/dandi_compute_code/queue/test_cli_queue_commands.py
@@ -497,6 +497,42 @@ def test_cli_queue_process_passes_jitter_seconds(tmp_path: pathlib.Path) -> None
 
 
 @pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    ("pending", "expected_exit_code", "expected_output"),
+    [
+        pytest.param(True, 0, "true", id="pending-exits-zero"),
+        pytest.param(False, 1, "false", id="not-pending-exits-one"),
+    ],
+)
+def test_cli_queue_pending_reports_and_sets_exit_code(
+    pending: bool, expected_exit_code: int, expected_output: str
+) -> None:
+    """dandicompute queue pending prints the boolean and exits 0 when pending, 1 otherwise."""
+    runner = CliRunner()
+
+    with mock.patch(
+        "dandi_compute_code._cli._dandicompute_group.has_pending_jobs", return_value=pending
+    ) as mock_has_pending:
+        result = runner.invoke(_dandicompute_group, ["queue", "pending"])
+
+    assert result.exit_code == expected_exit_code, result.output
+    mock_has_pending.assert_called_once_with()
+    assert expected_output in result.output
+
+
+@pytest.mark.ai_generated
+def test_cli_queue_pending_silent_suppresses_output(tmp_path: pathlib.Path) -> None:
+    """dandicompute queue pending --silent still sets the exit code but prints nothing."""
+    runner = CliRunner()
+
+    with mock.patch("dandi_compute_code._cli._dandicompute_group.has_pending_jobs", return_value=False):
+        result = runner.invoke(_dandicompute_group, ["queue", "pending", "--silent"])
+
+    assert result.exit_code == 1, result.output
+    assert "false" not in result.output
+
+
+@pytest.mark.ai_generated
 def test_cli_queue_process_passes_zero_jitter(tmp_path: pathlib.Path) -> None:
     """dandicompute queue process forwards --jitter 0 to process_queue."""
     queue_dir = _make_queue_dir(tmp_path)

--- a/tests/dandi_compute_code/queue/test_submit_next.py
+++ b/tests/dandi_compute_code/queue/test_submit_next.py
@@ -94,7 +94,7 @@ def test_submit_next_returns_false_and_logs_when_no_eligible_entries(
     with (
         caplog.at_level(logging.INFO, logger="dandi_compute_code.queue._submit_next"),
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=AssetsJsonldMetadata(content_id_to_asset={}, path_to_asset_metadata={}),
         ),
     ):
@@ -117,7 +117,7 @@ def test_submit_next_returns_false_when_all_submit_sh_have_submitted_marker(
     with (
         caplog.at_level(logging.INFO, logger="dandi_compute_code.queue._submit_next"),
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
     ):
@@ -139,7 +139,7 @@ def test_submit_next_calls_dandi_download_for_unsubmitted_candidate(tmp_path: pa
 
     with (
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(
@@ -171,7 +171,7 @@ def test_submit_next_calls_sbatch_with_submit_sh_path(tmp_path: pathlib.Path) ->
 
     with (
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(
@@ -204,7 +204,7 @@ def test_submit_next_writes_submitted_marker_adjacent_to_submit_sh(
     with (
         caplog.at_level(logging.INFO, logger="dandi_compute_code.queue._submit_next"),
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(
@@ -242,7 +242,7 @@ def test_submit_next_calls_dandi_upload_with_allow_any_path(tmp_path: pathlib.Pa
 
     with (
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(
@@ -272,7 +272,7 @@ def test_submit_next_cleans_up_temp_dir_on_success(tmp_path: pathlib.Path) -> No
 
     with (
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(
@@ -305,7 +305,7 @@ def test_submit_next_does_not_clean_up_temp_dir_on_download_failure(tmp_path: pa
 
     with (
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(
@@ -333,7 +333,7 @@ def test_submit_next_does_not_clean_up_temp_dir_in_test_mode(tmp_path: pathlib.P
 
     with (
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(
@@ -373,7 +373,7 @@ def test_submit_next_submits_up_to_max_submissions(tmp_path: pathlib.Path) -> No
 
     with (
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(
@@ -421,7 +421,7 @@ def test_submit_next_skips_candidates_with_submitted_in_metadata(tmp_path: pathl
 
     with (
         mock.patch(
-            "dandi_compute_code.queue._submit_next.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
             return_value=metadata,
         ),
         mock.patch(

--- a/tests/dandi_compute_code/queue/unit/test_has_pending_jobs.py
+++ b/tests/dandi_compute_code/queue/unit/test_has_pending_jobs.py
@@ -1,0 +1,74 @@
+from unittest import mock
+
+import pytest
+
+from dandi_compute_code.dandiset import AssetMetadata, AssetsJsonldMetadata
+from dandi_compute_code.queue import has_pending_jobs
+
+
+def _build_metadata(paths: list[str]) -> AssetsJsonldMetadata:
+    """Build minimal assets metadata indexed by path for the given asset paths."""
+    path_to_asset_metadata = {
+        path: AssetMetadata(
+            path=path,
+            date_modified="2026-01-01T00:00:00Z",
+            content_size=1,
+            content_id=f"content-{index}",
+        )
+        for index, path in enumerate(paths)
+    }
+    return AssetsJsonldMetadata(
+        content_id_to_asset={},
+        path_to_asset_metadata=path_to_asset_metadata,
+    )
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    ("paths", "expected"),
+    [
+        pytest.param([], False, id="empty-metadata"),
+        pytest.param(
+            ["sub-1/attempt-1/code/submit.sh"],
+            True,
+            id="single-unsubmitted",
+        ),
+        pytest.param(
+            ["sub-1/attempt-1/code/submit.sh", "sub-1/attempt-1/code/submitted"],
+            False,
+            id="submitted-plain-marker",
+        ),
+        pytest.param(
+            [
+                "sub-1/attempt-1/code/submit.sh",
+                "sub-1/attempt-1/code/submitted_date-2026+01+01_time-00+00+00",
+            ],
+            False,
+            id="submitted-dated-marker",
+        ),
+        pytest.param(
+            [
+                "sub-1/attempt-1/code/submit.sh",
+                "sub-1/attempt-1/code/submitted",
+                "sub-2/attempt-1/code/submit.sh",
+            ],
+            True,
+            id="mixed-one-pending",
+        ),
+        pytest.param(
+            ["sub-1/attempt-1/code/some_other_file.txt"],
+            False,
+            id="no-submit-script",
+        ),
+    ],
+)
+def test_has_pending_jobs(paths: list[str], expected: bool) -> None:
+    """has_pending_jobs reflects whether any submit.sh lacks a submitted marker."""
+    metadata = _build_metadata(paths)
+    with mock.patch(
+        "dandi_compute_code.queue._find_pending_entries.load_assets_jsonld_metadata",
+        return_value=metadata,
+    ):
+        result = has_pending_jobs()
+
+    assert result is expected


### PR DESCRIPTION
## Summary
This PR adds a new `dandicompute queue pending` command that checks whether any queued jobs are awaiting submission. This enables crontabs and automation scripts to skip queue dispatch when there is no work to process.

## Key Changes
- **New `has_pending_jobs()` function** (`_has_pending_jobs.py`): Lightweight check that reports whether any jobs are awaiting submission by inspecting DANDI assets metadata
- **New `_find_pending_entries()` helper** (`_find_pending_entries.py`): Extracted logic to identify attempt directories with `code/submit.sh` but no submitted marker (either `submitted` or `submitted_date-*` files)
- **New `queue pending` CLI command**: Reports pending status via exit code (0 when pending, 1 when empty) and optional text output
  - Supports `--silent` flag to suppress output while still setting exit code
  - Enables conditional dispatch: `dandicompute queue pending --silent && dandicompute queue process ...`
- **Refactored `_submit_next()`**: Now uses `_find_pending_entries()` instead of duplicating the pending detection logic
- **Updated test mocks**: All existing tests updated to mock `_find_pending_entries.load_assets_jsonld_metadata` instead of `_submit_next.load_assets_jsonld_metadata`
- **Documentation**: Added README section explaining the new `queue pending` command and its use case

## Implementation Details
- The pending detection logic is centralized in `_find_pending_entries()` to avoid duplication between `has_pending_jobs()` and `_submit_next()`
- A job is considered pending if it has a `code/submit.sh` asset without an adjacent submitted marker
- The check is lightweight and does not require SLURM access or actual job submission
- Exit codes follow Unix convention: 0 for success (pending work exists), 1 for no work

https://claude.ai/code/session_01VbNhBuPV7hx8wSt9Ddiyft