### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 12 * * *'  # 7 am EST every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy_tests_on_pull_request.yml
+++ b/.github/workflows/deploy_tests_on_pull_request.yml
@@ -6,6 +6,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/dandi-compute/code/security/code-scanning/6](https://github.com/dandi-compute/code/security/code-scanning/6)

Add an explicit `permissions` block to `.github/workflows/docs.yml` so the workflow does not inherit potentially broader defaults.  
Best fix without changing functionality: set workflow-level permissions to `contents: read`, which is sufficient for checkout and documentation build steps shown.

**Where to change:**  
- File: `.github/workflows/docs.yml`  
- Insert right after the `on:` trigger block (before `jobs:`), so it applies to all jobs in this workflow unless overridden.

**What is needed:**  
- No imports, methods, or dependencies.
- Only YAML key addition:
  - `permissions:`
  - `  contents: read`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
