### PR TITLE
Add explicit read-only permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 12 * * *'  # 7 am EST every day
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy_tests_on_pull_request.yml
+++ b/.github/workflows/deploy_tests_on_pull_request.yml
@@ -6,6 +6,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
This PR adds explicit `permissions` configuration to three GitHub Actions workflows, restricting them to read-only access to repository contents. This follows the principle of least privilege for workflow permissions.

## Key Changes
- Added `permissions: contents: read` to `.github/workflows/daily_tests.yml`
- Added `permissions: contents: read` to `.github/workflows/deploy_tests_on_pull_request.yml`
- Added `permissions: contents: read` to `.github/workflows/testing.yml`

## Implementation Details
The `permissions` block is placed at the workflow level (after the `on:` trigger configuration and before the `jobs:` or `concurrency:` sections) to establish a baseline permission set for all jobs in each workflow. By explicitly setting `contents: read`, these workflows declare that they only need to read repository contents and do not require write access or other elevated permissions. This improves security posture by preventing accidental or malicious privilege escalation.

https://claude.ai/code/session_012WrCgwsyw8Ewr7zibqK2o3