### PR TITLE
Fix content ID parsing to use raw strings instead of JSON

### DIFF
--- a/src/dandi_compute_code/queue/_prepare_queue.py
+++ b/src/dandi_compute_code/queue/_prepare_queue.py
@@ -66,7 +66,7 @@ def prepare_queue(
         )
         with urllib.request.urlopen(url=qualifying_aind_content_ids_url) as response:
             decompressed = gzip.decompress(response.read()).decode()
-            fetched_content_ids = [json.loads(line) for line in decompressed.splitlines() if line.strip()]
+            fetched_content_ids = [line.strip() for line in decompressed.splitlines() if line.strip()]
         content_ids = _order_content_ids_for_uniform_dandiset_sampling(content_ids=fetched_content_ids)
 
     state_file = queue_directory / "state.jsonl"

--- a/tests/dandi_compute_code/queue/_process_queue_test_cases.py
+++ b/tests/dandi_compute_code/queue/_process_queue_test_cases.py
@@ -131,7 +131,7 @@ def _read_jsonl(file_path: pathlib.Path) -> list[dict]:
 
 def _mock_urlopen_response(payload: list) -> mock.MagicMock:
     mock_response = mock.MagicMock()
-    jsonl = "\n".join(json.dumps(item) for item in payload)
+    jsonl = "\n".join(str(item) for item in payload)
     mock_response.read.return_value = gzip.compress(jsonl.encode())
     mock_response.__enter__.return_value = mock_response
     mock_response.__exit__.return_value = False


### PR DESCRIPTION
## Summary
Fixed the content ID parsing logic to treat each line as a raw string instead of attempting to parse it as JSON.

## Key Changes
- Changed `fetched_content_ids` population from `json.loads(line)` to `line.strip()`
- This simplifies the parsing logic and correctly handles the format of the fetched content IDs

## Implementation Details
The original code was attempting to parse each line as a JSON object, but the actual data format contains raw string values. By removing the `json.loads()` call and using `line.strip()` instead, the code now correctly extracts the content IDs as strings while maintaining the existing filter for empty lines.

https://claude.ai/code/session_011YbbxqswCjxxVpNCEZ3BMk