### PR TITLE
Change qualifying content IDs format from JSONL to JSON

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.37"
+version = "0.3.38"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/queue/_prepare_queue.py
+++ b/src/dandi_compute_code/queue/_prepare_queue.py
@@ -65,8 +65,7 @@ def prepare_queue(
             "derivatives/qualifying_aind_content_ids.jsonl.gz"
         )
         with urllib.request.urlopen(url=qualifying_aind_content_ids_url) as response:
-            decompressed = gzip.decompress(response.read()).decode()
-            fetched_content_ids = [line.strip() for line in decompressed.splitlines() if line.strip()]
+            fetched_content_ids = json.loads(gzip.decompress(response.read()).decode())
         content_ids = _order_content_ids_for_uniform_dandiset_sampling(content_ids=fetched_content_ids)
 
     state_file = queue_directory / "state.jsonl"

--- a/tests/dandi_compute_code/queue/_process_queue_test_cases.py
+++ b/tests/dandi_compute_code/queue/_process_queue_test_cases.py
@@ -131,8 +131,7 @@ def _read_jsonl(file_path: pathlib.Path) -> list[dict]:
 
 def _mock_urlopen_response(payload: list) -> mock.MagicMock:
     mock_response = mock.MagicMock()
-    jsonl = "\n".join(str(item) for item in payload)
-    mock_response.read.return_value = gzip.compress(jsonl.encode())
+    mock_response.read.return_value = gzip.compress(json.dumps(payload).encode())
     mock_response.__enter__.return_value = mock_response
     mock_response.__exit__.return_value = False
     return mock_response


### PR DESCRIPTION
## Summary
This PR updates the format of the qualifying AIND content IDs from JSONL (JSON Lines) to a single JSON array, simplifying the data structure and parsing logic.

## Key Changes
- **Queue preparation**: Modified `prepare_queue()` to parse the fetched content IDs as a JSON array instead of JSONL format, eliminating the need for line-by-line processing
- **Test mocking**: Updated `_mock_urlopen_response()` to generate a JSON array payload instead of JSONL format, keeping tests aligned with the new implementation
- **Version bump**: Incremented version from 0.3.37 to 0.3.38

## Implementation Details
The change simplifies the deserialization logic by:
- Replacing manual line splitting and stripping with a single `json.loads()` call
- Removing intermediate variable `decompressed` for cleaner code
- Using `json.dumps()` in tests to match the new format

This is a more straightforward approach for handling a list of content IDs and reduces parsing complexity.

https://claude.ai/code/session_011YbbxqswCjxxVpNCEZ3BMk