### PR TITLE
Rename content-id-to-unique-dandiset-path to content-id-to-usage-dandiset-path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.37"
+version = "0.3.38"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/aind_ephys_pipeline/_prepare_job.py
+++ b/src/dandi_compute_code/aind_ephys_pipeline/_prepare_job.py
@@ -199,22 +199,22 @@ def prepare_aind_ephys_job(
     config_id = actual_config_md5[0:7]
 
     dandi_compute_dir = pathlib.Path("/orcd/data/dandi/001/dandi-compute")
-    content_id_to_unique_dandiset_path_url = (
-        "https://raw.githubusercontent.com/dandi-cache/content-id-to-unique-dandiset-path/refs/heads/min/"
-        "derivatives/content_id_to_unique_dandiset_path.min.json.gz"
+    content_id_to_usage_dandiset_path_url = (
+        "https://raw.githubusercontent.com/dandi-cache/content-id-to-usage-dandiset-path/min/"
+        "derivatives/content_id_to_usage_dandiset_path.min.json.gz"
     )
-    with urllib.request.urlopen(url=content_id_to_unique_dandiset_path_url) as response:
-        content_id_to_unique_dandiset_path = json.loads(gzip.decompress(response.read()))
+    with urllib.request.urlopen(url=content_id_to_usage_dandiset_path_url) as response:
+        content_id_to_usage_dandiset_path = json.loads(gzip.decompress(response.read()))
 
-    if content_id not in content_id_to_unique_dandiset_path:
+    if content_id not in content_id_to_usage_dandiset_path:
         message = (
-            f"Content ID {content_id} not found in content ID to unique Dandiset path mapping. "
+            f"Content ID {content_id} not found in content ID to usage Dandiset path mapping. "
             "This likely means that the content ID is not associated with a Dandiset, "
             "or that the mapping file is out of date."
         )
         raise UnmappedContentIDError(message)
 
-    dandiset_id, dandiset_path = next(iter(content_id_to_unique_dandiset_path[content_id].items()))
+    dandiset_id, dandiset_path = next(iter(content_id_to_usage_dandiset_path[content_id].items()))
     if dandiset_id == _SANDBOX_DANDISET_ID:
         message = (
             f"Content ID {content_id} maps to sandbox dandiset {_SANDBOX_DANDISET_ID}, "

--- a/src/dandi_compute_code/dandiset/_globals.py
+++ b/src/dandi_compute_code/dandiset/_globals.py
@@ -7,8 +7,8 @@ _ATTEMPT_DIR_RE = re.compile(
 _ATTEMPT_SUFFIX_RE = re.compile(r"_attempt-\d+$")
 _SANDBOX_DANDISET_ID = "214527"
 _SANDBOX_API_URL = "https://api.sandbox.dandiarchive.org/api"
-_CONTENT_ID_TO_UNIQUE_DANDISET_PATH_URL = (
-    "https://raw.githubusercontent.com/dandi-cache/content-id-to-unique-dandiset-path/refs/heads/min/"
-    "derivatives/content_id_to_unique_dandiset_path.min.json.gz"
+_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL = (
+    "https://raw.githubusercontent.com/dandi-cache/content-id-to-usage-dandiset-path/min/"
+    "derivatives/content_id_to_usage_dandiset_path.min.json.gz"
 )
 _ASSETS_JSONLD_URL = "https://dandiarchive.s3.amazonaws.com/dandisets/001697/draft/assets.jsonld"

--- a/src/dandi_compute_code/dandiset/_load_content_id_to_usage_dandiset_path.py
+++ b/src/dandi_compute_code/dandiset/_load_content_id_to_usage_dandiset_path.py
@@ -3,13 +3,13 @@ import gzip
 import json
 import urllib.request
 
-from ._globals import _CONTENT_ID_TO_UNIQUE_DANDISET_PATH_URL
+from ._globals import _CONTENT_ID_TO_USAGE_DANDISET_PATH_URL
 
 
 @functools.lru_cache(maxsize=1)
-def _load_content_id_to_unique_dandiset_path() -> dict[str, dict[str, str]]:
+def _load_content_id_to_usage_dandiset_path() -> dict[str, dict[str, str]]:
     """
-    Load the content ID to unique Dandiset path mapping.
+    Load the content ID to usage Dandiset path mapping.
 
     Raises
     ------
@@ -18,11 +18,11 @@ def _load_content_id_to_unique_dandiset_path() -> dict[str, dict[str, str]]:
         The original exception is chained via ``raise ... from``.
     """
     try:
-        with urllib.request.urlopen(url=_CONTENT_ID_TO_UNIQUE_DANDISET_PATH_URL) as response:
+        with urllib.request.urlopen(url=_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL) as response:
             return json.loads(gzip.decompress(response.read()))
     except Exception as exception:
         message = (
-            "Unable to load content-id-to-unique-dandiset-path mapping from "
-            f"{_CONTENT_ID_TO_UNIQUE_DANDISET_PATH_URL}"
+            "Unable to load content-id-to-usage-dandiset-path mapping from "
+            f"{_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL}"
         )
         raise RuntimeError(message) from exception

--- a/src/dandi_compute_code/dandiset/_load_content_id_to_usage_dandiset_path.py
+++ b/src/dandi_compute_code/dandiset/_load_content_id_to_usage_dandiset_path.py
@@ -22,7 +22,6 @@ def _load_content_id_to_usage_dandiset_path() -> dict[str, dict[str, str]]:
             return json.loads(gzip.decompress(response.read()))
     except Exception as exception:
         message = (
-            "Unable to load content-id-to-usage-dandiset-path mapping from "
-            f"{_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL}"
+            "Unable to load content-id-to-usage-dandiset-path mapping from " f"{_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL}"
         )
         raise RuntimeError(message) from exception

--- a/src/dandi_compute_code/dandiset/_lookup_asset_size_bytes.py
+++ b/src/dandi_compute_code/dandiset/_lookup_asset_size_bytes.py
@@ -1,7 +1,7 @@
 import logging
 
 from ._create_dandi_api_client import _create_dandi_api_client
-from ._load_content_id_to_unique_dandiset_path import _load_content_id_to_unique_dandiset_path
+from ._load_content_id_to_usage_dandiset_path import _load_content_id_to_usage_dandiset_path
 from ._normalize_asset_path import _normalize_asset_path
 
 _log = logging.getLogger(__name__)
@@ -30,17 +30,17 @@ def _lookup_asset_size_bytes(
         Either tuple value can be ``None`` when lookup conditions are not met.
     :rtype: tuple[int | None, str | None]
     """
-    content_id_to_unique_dandiset_path = _load_content_id_to_unique_dandiset_path()
-    if content_id not in content_id_to_unique_dandiset_path:
+    content_id_to_usage_dandiset_path = _load_content_id_to_usage_dandiset_path()
+    if content_id not in content_id_to_usage_dandiset_path:
         _log.warning(
             (
                 f"Unable to resolve asset_size_bytes for {content_id}. "
-                "Content ID is not present in content-id-to-unique-dandiset-path mapping."
+                "Content ID is not present in content-id-to-usage-dandiset-path mapping."
             ),
         )
         return None, None
 
-    mapped_dandiset_path = content_id_to_unique_dandiset_path[content_id]
+    mapped_dandiset_path = content_id_to_usage_dandiset_path[content_id]
     if len(mapped_dandiset_path) != 1:
         _log.warning(
             (

--- a/src/dandi_compute_code/queue/_order_content_ids_for_uniform_dandiset_sampling.py
+++ b/src/dandi_compute_code/queue/_order_content_ids_for_uniform_dandiset_sampling.py
@@ -1,7 +1,7 @@
 import collections
 import random
 
-from ..dandiset._load_content_id_to_unique_dandiset_path import _load_content_id_to_unique_dandiset_path
+from ..dandiset._load_content_id_to_usage_dandiset_path import _load_content_id_to_usage_dandiset_path
 
 
 def _order_content_ids_for_uniform_dandiset_sampling(*, content_ids: list[str]) -> list[str]:
@@ -12,7 +12,7 @@ def _order_content_ids_for_uniform_dandiset_sampling(*, content_ids: list[str]) 
     singleton groups so they remain eligible without being merged into the
     randomization for any unrelated Dandiset.
     """
-    content_id_to_dandiset_path = _load_content_id_to_unique_dandiset_path()
+    content_id_to_dandiset_path = _load_content_id_to_usage_dandiset_path()
     content_ids_by_dandiset: dict[str | tuple[str, str], list[str]] = {}
     for content_id in content_ids:
         content_id_mapping = content_id_to_dandiset_path.get(content_id, {})

--- a/tests/dandi_compute_code/queue/_process_queue_test_cases.py
+++ b/tests/dandi_compute_code/queue/_process_queue_test_cases.py
@@ -90,7 +90,7 @@ def mock_scan_dandi_api_asset_lookup() -> Iterator[None]:
             return_value=_EmptyClient(),
         ),
         mock.patch(
-            "dandi_compute_code.dandiset._lookup_asset_size_bytes._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.dandiset._lookup_asset_size_bytes._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
     ):
@@ -1496,7 +1496,7 @@ def test_prepare_queue_calls_prepare_for_each_qualifying_asset(tmp_path: pathlib
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -1559,7 +1559,7 @@ def test_prepare_queue_skips_when_failures_reach_max(tmp_path: pathlib.Path) -> 
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -1585,7 +1585,7 @@ def test_prepare_queue_strips_commit_suffix_from_version(tmp_path: pathlib.Path)
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -1610,7 +1610,7 @@ def test_prepare_queue_passes_optional_args_through(tmp_path: pathlib.Path) -> N
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -1638,7 +1638,7 @@ def test_prepare_queue_limit_stops_after_n_assets(tmp_path: pathlib.Path) -> Non
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -1663,7 +1663,7 @@ def test_prepare_queue_limit_samples_uniformly_over_dandisets(tmp_path: pathlib.
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value=content_id_mapping,
         ),
         mock.patch(
@@ -1724,7 +1724,7 @@ def test_prepare_queue_warns_and_continues_for_unmapped_content_id(
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch(

--- a/tests/dandi_compute_code/queue/test_prepare_queue.py
+++ b/tests/dandi_compute_code/queue/test_prepare_queue.py
@@ -47,7 +47,7 @@ def test_prepare_queue_calls_prepare_for_each_qualifying_asset(tmp_path: pathlib
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -110,7 +110,7 @@ def test_prepare_queue_skips_when_failures_reach_max(tmp_path: pathlib.Path) -> 
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -136,7 +136,7 @@ def test_prepare_queue_passes_optional_args_through(tmp_path: pathlib.Path) -> N
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -164,7 +164,7 @@ def test_prepare_queue_limit_stops_after_n_assets(tmp_path: pathlib.Path) -> Non
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value={},
         ),
         mock.patch("dandi_compute_code.queue._prepare_queue.prepare_aind_ephys_job") as mock_prepare,
@@ -189,7 +189,7 @@ def test_prepare_queue_limit_samples_uniformly_over_dandisets(tmp_path: pathlib.
     with (
         mock.patch("urllib.request.urlopen") as mock_urlopen,
         mock.patch(
-            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_unique_dandiset_path",
+            "dandi_compute_code.queue._order_content_ids_for_uniform_dandiset_sampling._load_content_id_to_usage_dandiset_path",
             return_value=content_id_mapping,
         ),
         mock.patch(


### PR DESCRIPTION
## Summary
This PR updates all references to the content ID mapping from "unique" to "usage" dandiset paths, reflecting a change in the upstream data source and its semantics.

## Key Changes
- Renamed the mapping file from `content-id-to-unique-dandiset-path` to `content-id-to-usage-dandiset-path` across all references
- Updated the GitHub repository URL from `dandi-cache/content-id-to-unique-dandiset-path` to `dandi-cache/content-id-to-usage-dandiset-path`
- Updated the file path from `derivatives/content_id_to_unique_dandiset_path.min.json.gz` to `derivatives/content_id_to_usage_dandiset_path.min.json.gz`
- Renamed function `_load_content_id_to_unique_dandiset_path()` to `_load_content_id_to_usage_dandiset_path()`
- Renamed file `_load_content_id_to_unique_dandiset_path.py` to `_load_content_id_to_usage_dandiset_path.py`
- Updated all variable names from `content_id_to_unique_dandiset_path` to `content_id_to_usage_dandiset_path`
- Updated all error messages and log messages to reference "usage" instead of "unique"
- Updated all mock patch paths in tests to reference the new function name
- Updated the global constant `_CONTENT_ID_TO_UNIQUE_DANDISET_PATH_URL` to `_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL`

## Implementation Details
- The change is purely a rename/refactor with no functional logic changes
- All imports and references have been updated consistently across the codebase
- Test mocks have been updated to match the new function names
- The URL structure has been simplified (removed `refs/heads/` from the path)

https://claude.ai/code/session_011KQexBCcC3aJmoQ1cDLjBN