### PR TITLE
Fix JSON Lines parsing of content IDs from qualifying file

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,0 +1,33 @@
+name: Version Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "pyproject.toml"
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        run: |
+          git show origin/${{ github.base_ref }}:pyproject.toml > /tmp/base_pyproject.toml
+          PR_VERSION=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          BASE_VERSION=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('/tmp/base_pyproject.toml').read_text())['project']['version'])")
+          echo "Base version: $BASE_VERSION"
+          echo "PR version:   $PR_VERSION"
+          if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+            echo "::error::Version has not been bumped. Please update the version in pyproject.toml."
+            exit 1
+          fi
+          echo "Version bumped from $BASE_VERSION to $PR_VERSION ✓"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Prefer assigning return values to named locals before `return` when this improves readability and debugger breakpoint placement.
 - Avoid excessive em-dashes, colons, and semicolons in written text such as documentation. Prefer breaking into separate, shorter sentences instead.
 - Favor defining one-word names for CLI flags, then map those onto longer, more explicit keyword arguments at the API level.
+- Keep inline comments sparse. Only explain non-obvious "why", not "what" the code does. Prefer self-documenting code and clear names over narration; do not annotate routine logic.
 
 ## Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.38"
+version = "0.3.39"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/queue/_prepare_queue.py
+++ b/src/dandi_compute_code/queue/_prepare_queue.py
@@ -66,10 +66,6 @@ def prepare_queue(
         )
         with urllib.request.urlopen(url=qualifying_aind_content_ids_url) as response:
             decompressed = gzip.decompress(response.read()).decode()
-            # The file is JSON Lines: each line is a JSON-encoded content ID string
-            # (e.g. `"019fac19-..."`). Decode each line so the surrounding quotes are
-            # stripped; otherwise the quoted value never matches the bare-UUID keys in
-            # the content-ID-to-usage-Dandiset-path mapping.
             fetched_content_ids = [json.loads(line) for line in decompressed.splitlines() if line.strip()]
         content_ids = _order_content_ids_for_uniform_dandiset_sampling(content_ids=fetched_content_ids)
 

--- a/src/dandi_compute_code/queue/_prepare_queue.py
+++ b/src/dandi_compute_code/queue/_prepare_queue.py
@@ -66,7 +66,11 @@ def prepare_queue(
         )
         with urllib.request.urlopen(url=qualifying_aind_content_ids_url) as response:
             decompressed = gzip.decompress(response.read()).decode()
-            fetched_content_ids = [line.strip() for line in decompressed.splitlines() if line.strip()]
+            # The file is JSON Lines: each line is a JSON-encoded content ID string
+            # (e.g. `"019fac19-..."`). Decode each line so the surrounding quotes are
+            # stripped; otherwise the quoted value never matches the bare-UUID keys in
+            # the content-ID-to-usage-Dandiset-path mapping.
+            fetched_content_ids = [json.loads(line) for line in decompressed.splitlines() if line.strip()]
         content_ids = _order_content_ids_for_uniform_dandiset_sampling(content_ids=fetched_content_ids)
 
     state_file = queue_directory / "state.jsonl"

--- a/tests/dandi_compute_code/queue/_process_queue_test_cases.py
+++ b/tests/dandi_compute_code/queue/_process_queue_test_cases.py
@@ -131,7 +131,6 @@ def _read_jsonl(file_path: pathlib.Path) -> list[dict]:
 
 def _mock_urlopen_response(payload: list) -> mock.MagicMock:
     mock_response = mock.MagicMock()
-    # The qualifying-content-ids file is JSON Lines: each line is a JSON-encoded value.
     jsonl = "\n".join(json.dumps(item) for item in payload)
     mock_response.read.return_value = gzip.compress(jsonl.encode())
     mock_response.__enter__.return_value = mock_response

--- a/tests/dandi_compute_code/queue/_process_queue_test_cases.py
+++ b/tests/dandi_compute_code/queue/_process_queue_test_cases.py
@@ -131,7 +131,8 @@ def _read_jsonl(file_path: pathlib.Path) -> list[dict]:
 
 def _mock_urlopen_response(payload: list) -> mock.MagicMock:
     mock_response = mock.MagicMock()
-    jsonl = "\n".join(str(item) for item in payload)
+    # The qualifying-content-ids file is JSON Lines: each line is a JSON-encoded value.
+    jsonl = "\n".join(json.dumps(item) for item in payload)
     mock_response.read.return_value = gzip.compress(jsonl.encode())
     mock_response.__enter__.return_value = mock_response
     mock_response.__exit__.return_value = False


### PR DESCRIPTION
## Summary
Fixed incorrect parsing of the qualifying content IDs file by properly decoding JSON Lines format. The file contains JSON-encoded strings (with surrounding quotes), which must be decoded to extract the bare UUID values that match the keys in the content-ID-to-usage mapping.

## Changes
- **Production code**: Updated `prepare_queue()` to use `json.loads()` instead of simple string stripping when parsing the fetched content IDs, ensuring JSON-encoded strings are properly decoded
- **Test code**: Updated the mock response generator to properly encode content IDs as JSON strings using `json.dumps()`, matching the actual file format
- Added clarifying comments explaining the JSON Lines format and why JSON decoding is necessary

## Implementation Details
The qualifying content IDs file uses JSON Lines format where each line is a JSON-encoded string (e.g., `"019fac19-..."`). The previous implementation only stripped whitespace, leaving the surrounding quotes intact. This caused the quoted values to never match the bare-UUID keys in the content-ID-to-usage-Dandiset-path mapping. Using `json.loads()` properly decodes each line to extract the actual UUID string.

https://claude.ai/code/session_01Sv9XGNZeaMUPQkACdX4EgT