### PR TITLE
Add archive capsule command to move failed job runs to permanent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dandicompute queue clean --queue ./queue/ --dandiset ./dandi/001697/
 To archive a failed job capsule by moving it from `001697` to the permanent archive `001873`:
 
 ```bash
-dandicompute archive capsule --path derivatives/dandiset-000409/sub-mouse01/pipeline-aind+ephys/version-v1.0_params-default_config-abc123_attempt-1
+dandicompute archive job --path derivatives/dandiset-000409/sub-mouse01/pipeline-aind+ephys/version-v1.0_params-default_config-abc123_attempt-1
 ```
 
 The capsule subtree is downloaded into a scratch directory, uploaded to `001873`, and only then deleted from `001697`. The scratch directory is cleaned up on success. A failed upload never removes the original.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ To clean unsubmitted job capsules:
 dandicompute queue clean --queue ./queue/ --dandiset ./dandi/001697/
 ```
 
+To archive a failed job capsule by moving it from `001697` to the permanent archive `001873`:
+
+```bash
+dandicompute archive capsule --path derivatives/dandiset-000409/sub-mouse01/pipeline-aind+ephys/version-v1.0_params-default_config-abc123_attempt-1
+```
+
+The capsule subtree is downloaded into a scratch directory, uploaded to `001873`, and only then deleted from `001697`. The scratch directory is cleaned up on success. A failed upload never removes the original.
+
 To check whether there is any queued work before dispatching, use `queue pending`. It exits with code 0 when at least one job is awaiting submission, and code 1 when there is nothing to process. This lets a crontab skip the dispatch entirely when the queue is empty:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ To archive a failed job capsule by moving it from `001697` to the permanent arch
 dandicompute archive job --path derivatives/dandiset-000409/sub-mouse01/pipeline-aind+ephys/version-v1.0_params-default_config-abc123_attempt-1
 ```
 
-The capsule subtree is downloaded into a scratch directory, uploaded to `001873`, and only then deleted from `001697`. The scratch directory is cleaned up on success. A failed upload never removes the original.
 
 To check whether there is any queued work before dispatching, use `queue pending`. It exits with code 0 when at least one job is awaiting submission, and code 1 when there is nothing to process. This lets a crontab skip the dispatch entirely when the queue is empty:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.40"
+version = "0.3.41"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/_cli/_dandicompute_group.py
+++ b/src/dandi_compute_code/_cli/_dandicompute_group.py
@@ -10,6 +10,7 @@ from .._configure_logging import _configure_logging
 from ..aind_ephys_pipeline import prepare_aind_ephys_job, submit_job
 from ..dandiset import (
     delete_dandiset_version,
+    move_job_capsule,
     scan_version_directories,
 )
 from ..queue import (
@@ -683,6 +684,59 @@ def _delete_version_command(dandiset_directory: pathlib.Path, version: str, sile
         _styled_echo(text=f"\nDeleted {len(deleted)} version {noun}.", color="green")
 
 
+# dandicompute archive
+@_dandicompute_group.group(name="archive")
+def _archive_group() -> None:
+    """Move job capsules into the permanent archive of failed job runs."""
+    pass
+
+
+# dandicompute archive capsule [OPTIONS]
+@_archive_group.command(name="capsule")
+@click.option(
+    "--path",
+    "capsule_path",
+    help="Path of the job capsule folder relative to the source Dandiset root.",
+    required=True,
+    type=str,
+)
+@click.option(
+    "--scratch",
+    "scratch_directory",
+    help="Directory for the temporary working tree (defaults to the system temporary location).",
+    required=False,
+    type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
+    default=None,
+)
+@click.option(
+    "--test",
+    "test",
+    help="Preserve the scratch directory instead of cleaning it up.",
+    required=False,
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--silent",
+    help="Suppress informational log output.",
+    required=False,
+    is_flag=True,
+    default=False,
+)
+def _archive_capsule_command(
+    capsule_path: str,
+    scratch_directory: pathlib.Path | None = None,
+    test: bool = False,
+    silent: bool = False,
+) -> None:
+    """Move a job capsule from the job capsules Dandiset to the failed runs archive."""
+    _configure_logging(silent=silent)
+    _require_dandi_api_key()
+    move_job_capsule(capsule_path=capsule_path, scratch_directory=scratch_directory, test=test)
+    if not silent:
+        _styled_echo(text=f"\nArchived job capsule: {capsule_path}", color="green")
+
+
 # Required for daily tests
 _dandicompute_group.prepare_queue = prepare_queue
 _dandicompute_group.prepare_aind_ephys_job = prepare_aind_ephys_job
@@ -693,3 +747,4 @@ _dandicompute_group.summarize_issues = summarize_issues
 _dandicompute_group.process_queue = process_queue
 _dandicompute_group.has_pending_jobs = has_pending_jobs
 _dandicompute_group.write_queue_state = write_queue_state
+_dandicompute_group.move_job_capsule = move_job_capsule

--- a/src/dandi_compute_code/_cli/_dandicompute_group.py
+++ b/src/dandi_compute_code/_cli/_dandicompute_group.py
@@ -701,8 +701,8 @@ def _archive_group() -> None:
     type=str,
 )
 @click.option(
-    "--scratch",
-    "scratch_directory",
+    "--processing",
+    "processing_directory",
     help="Directory for the temporary working tree (defaults to the system temporary location).",
     required=False,
     type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
@@ -711,7 +711,7 @@ def _archive_group() -> None:
 @click.option(
     "--test",
     "test",
-    help="Preserve the scratch directory instead of cleaning it up.",
+    help="Preserve the temporary working tree instead of cleaning it up.",
     required=False,
     is_flag=True,
     default=False,
@@ -725,14 +725,14 @@ def _archive_group() -> None:
 )
 def _archive_job_command(
     capsule_path: str,
-    scratch_directory: pathlib.Path | None = None,
+    processing_directory: pathlib.Path | None = None,
     test: bool = False,
     silent: bool = False,
 ) -> None:
     """Move a job capsule from the job capsules Dandiset to the failed runs archive."""
     _configure_logging(silent=silent)
     _require_dandi_api_key()
-    move_job_capsule(capsule_path=capsule_path, scratch_directory=scratch_directory, test=test)
+    move_job_capsule(capsule_path=capsule_path, processing_directory=processing_directory, test=test)
     if not silent:
         _styled_echo(text=f"\nArchived job capsule: {capsule_path}", color="green")
 

--- a/src/dandi_compute_code/_cli/_dandicompute_group.py
+++ b/src/dandi_compute_code/_cli/_dandicompute_group.py
@@ -691,8 +691,8 @@ def _archive_group() -> None:
     pass
 
 
-# dandicompute archive capsule [OPTIONS]
-@_archive_group.command(name="capsule")
+# dandicompute archive job [OPTIONS]
+@_archive_group.command(name="job")
 @click.option(
     "--path",
     "capsule_path",
@@ -723,7 +723,7 @@ def _archive_group() -> None:
     is_flag=True,
     default=False,
 )
-def _archive_capsule_command(
+def _archive_job_command(
     capsule_path: str,
     scratch_directory: pathlib.Path | None = None,
     test: bool = False,

--- a/src/dandi_compute_code/dandiset/__init__.py
+++ b/src/dandi_compute_code/dandiset/__init__.py
@@ -1,5 +1,6 @@
 from ._delete_dandiset_version import delete_dandiset_version
 from ._load_assets_jsonld_metadata import AssetMetadata, AssetsJsonldMetadata, load_assets_jsonld_metadata
+from ._move_job_capsule import move_job_capsule
 from ._scan_version_directories import scan_version_directories
 
 __all__ = [
@@ -7,5 +8,6 @@ __all__ = [
     "AssetsJsonldMetadata",
     "delete_dandiset_version",
     "load_assets_jsonld_metadata",
+    "move_job_capsule",
     "scan_version_directories",
 ]

--- a/src/dandi_compute_code/dandiset/_globals.py
+++ b/src/dandi_compute_code/dandiset/_globals.py
@@ -6,6 +6,8 @@ _ATTEMPT_DIR_RE = re.compile(
 )
 _ATTEMPT_SUFFIX_RE = re.compile(r"_attempt-\d+$")
 _SANDBOX_DANDISET_ID = "214527"
+_JOB_CAPSULES_DANDISET_ID = "001697"
+_FAILED_RUNS_ARCHIVE_DANDISET_ID = "001873"
 _SANDBOX_API_URL = "https://api.sandbox.dandiarchive.org/api"
 _CONTENT_ID_TO_USAGE_DANDISET_PATH_URL = (
     "https://raw.githubusercontent.com/dandi-cache/content-id-to-usage-dandiset-path/min/"

--- a/src/dandi_compute_code/dandiset/_move_job_capsule.py
+++ b/src/dandi_compute_code/dandiset/_move_job_capsule.py
@@ -1,0 +1,143 @@
+import logging
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+
+from ._globals import _FAILED_RUNS_ARCHIVE_DANDISET_ID, _JOB_CAPSULES_DANDISET_ID
+
+_log = logging.getLogger(__name__)
+
+
+def move_job_capsule(
+    *,
+    capsule_path: str,
+    source_dandiset_id: str = _JOB_CAPSULES_DANDISET_ID,
+    target_dandiset_id: str = _FAILED_RUNS_ARCHIVE_DANDISET_ID,
+    scratch_directory: pathlib.Path | None = None,
+    test: bool = False,
+) -> None:
+    """
+    Move a single job capsule folder from one Dandiset to another.
+
+    The capsule subtree is downloaded from *source_dandiset_id* into a fresh
+    scratch directory via ``dandi download --preserve-tree``, copied under a
+    locally materialized copy of the *target_dandiset_id* tree, uploaded via
+    ``dandi upload --allow-any-path``, and only then removed from
+    *source_dandiset_id* via ``dandi delete``. The scratch directory is removed
+    on success. Each step is restricted to the single capsule subtree so the
+    operation touches the minimum number of assets.
+
+    The path of the capsule inside the Dandiset is preserved exactly. Only the
+    enclosing Dandiset changes. Deletion from the source happens only after the
+    upload to the target succeeds, so a failed upload never destroys the
+    original.
+
+    Parameters
+    ----------
+    capsule_path : str
+        Path of the job capsule folder relative to the Dandiset root (for
+        example ``derivatives/dandiset-000409/sub-mouse01/pipeline-aind+ephys/
+        version-v1.0_params-default_config-abc123_attempt-1``).
+    source_dandiset_id : str, optional
+        Dandiset the capsule is moved from. Defaults to the job capsules
+        Dandiset (``001697``).
+    target_dandiset_id : str, optional
+        Dandiset the capsule is moved to. Defaults to the failed runs archive
+        Dandiset (``001873``).
+    scratch_directory : pathlib.Path, optional
+        Directory in which the temporary per-capsule working tree is created.
+        When ``None``, the system default temporary location is used.
+    test : bool, optional
+        When ``True``, leave the scratch directory on disk after a successful
+        move for debugging.
+
+    Raises
+    ------
+    RuntimeError
+        If ``DANDI_API_KEY`` is unset or blank, or if any ``dandi`` subprocess
+        returns a non-zero exit code. The scratch directory is intentionally
+        left in place when any step fails so that it can be inspected.
+    """
+    if not os.environ.get("DANDI_API_KEY", "").strip():
+        message = "`DANDI_API_KEY` environment variable is not set or is blank."
+        raise RuntimeError(message)
+
+    relative_capsule_path = capsule_path.strip("/")
+
+    scratch_root = pathlib.Path(tempfile.mkdtemp(dir=scratch_directory, prefix="move-capsule-"))
+    _log.info(
+        "Moving job capsule %s from %s to %s in %s",
+        relative_capsule_path,
+        source_dandiset_id,
+        target_dandiset_id,
+        scratch_root,
+    )
+
+    source_url = f"dandi://dandi/{source_dandiset_id}/{relative_capsule_path}/"
+    download = subprocess.run(
+        ["dandi", "download", "--preserve-tree", source_url],
+        capture_output=True,
+        text=True,
+        cwd=scratch_root,
+    )
+    _log.info("dandi download returned code %d for %s", download.returncode, source_url)
+    _log.debug("dandi download stdout: %s\nstderr: %s", download.stdout, download.stderr)
+    if download.returncode != 0:
+        _log.warning("dandi download stdout: %s\nstderr: %s", download.stdout, download.stderr)
+        message = f"dandi download failed for {source_url}"
+        raise RuntimeError(message)
+
+    target_url = f"dandi://dandi/{target_dandiset_id}/"
+    metadata_download = subprocess.run(
+        ["dandi", "download", "--download", "dandiset.yaml", target_url],
+        capture_output=True,
+        text=True,
+        cwd=scratch_root,
+    )
+    _log.info("dandi download of dandiset.yaml returned code %d for %s", metadata_download.returncode, target_url)
+    _log.debug("dandi download stdout: %s\nstderr: %s", metadata_download.stdout, metadata_download.stderr)
+    if metadata_download.returncode != 0:
+        _log.warning("dandi download stdout: %s\nstderr: %s", metadata_download.stdout, metadata_download.stderr)
+        message = f"dandi download of dandiset.yaml failed for {target_url}"
+        raise RuntimeError(message)
+
+    source_capsule_directory = scratch_root / source_dandiset_id / relative_capsule_path
+    target_capsule_directory = scratch_root / target_dandiset_id / relative_capsule_path
+    target_capsule_directory.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_capsule_directory, target_capsule_directory)
+
+    target_dandiset_directory = scratch_root / target_dandiset_id
+    upload = subprocess.run(
+        ["dandi", "upload", "--allow-any-path", relative_capsule_path],
+        capture_output=True,
+        text=True,
+        cwd=target_dandiset_directory,
+    )
+    _log.info("dandi upload returned code %d for %s", upload.returncode, target_url)
+    _log.debug("dandi upload stdout: %s\nstderr: %s", upload.stdout, upload.stderr)
+    if upload.returncode != 0:
+        _log.warning("dandi upload stdout: %s\nstderr: %s", upload.stdout, upload.stderr)
+        message = f"dandi upload failed for {target_url}{relative_capsule_path}"
+        raise RuntimeError(message)
+
+    delete = subprocess.run(
+        ["dandi", "delete", str(source_capsule_directory)],
+        input=b"y\n",
+        capture_output=True,
+    )
+    _log.info("dandi delete returned code %d for %s", delete.returncode, source_url)
+    _log.debug("dandi delete stdout: %s\nstderr: %s", delete.stdout, delete.stderr)
+    if delete.returncode != 0:
+        _log.warning("dandi delete stdout: %s\nstderr: %s", delete.stdout, delete.stderr)
+        message = (
+            f"dandi delete failed for {source_url}; the capsule was uploaded to {target_dandiset_id} "
+            f"but could not be removed from {source_dandiset_id}"
+        )
+        raise RuntimeError(message)
+
+    if test:
+        _log.info("Leaving scratch directory in place for test mode: %s", scratch_root)
+    else:
+        shutil.rmtree(scratch_root)

--- a/src/dandi_compute_code/dandiset/_move_job_capsule.py
+++ b/src/dandi_compute_code/dandiset/_move_job_capsule.py
@@ -15,19 +15,19 @@ def move_job_capsule(
     capsule_path: str,
     source_dandiset_id: str = _JOB_CAPSULES_DANDISET_ID,
     target_dandiset_id: str = _FAILED_RUNS_ARCHIVE_DANDISET_ID,
-    scratch_directory: pathlib.Path | None = None,
+    processing_directory: pathlib.Path | None = None,
     test: bool = False,
 ) -> None:
     """
     Move a single job capsule folder from one Dandiset to another.
 
     The capsule subtree is downloaded from *source_dandiset_id* into a fresh
-    scratch directory via ``dandi download --preserve-tree``, copied under a
-    locally materialized copy of the *target_dandiset_id* tree, uploaded via
+    temporary working tree via ``dandi download --preserve-tree``, copied under
+    a locally materialized copy of the *target_dandiset_id* tree, uploaded via
     ``dandi upload --allow-any-path``, and only then removed from
-    *source_dandiset_id* via ``dandi delete``. The scratch directory is removed
-    on success. Each step is restricted to the single capsule subtree so the
-    operation touches the minimum number of assets.
+    *source_dandiset_id* via ``dandi delete``. The temporary working tree is
+    removed on success. Each step is restricted to the single capsule subtree
+    so the operation touches the minimum number of assets.
 
     The path of the capsule inside the Dandiset is preserved exactly. Only the
     enclosing Dandiset changes. Deletion from the source happens only after the
@@ -46,19 +46,20 @@ def move_job_capsule(
     target_dandiset_id : str, optional
         Dandiset the capsule is moved to. Defaults to the failed runs archive
         Dandiset (``001873``).
-    scratch_directory : pathlib.Path, optional
+    processing_directory : pathlib.Path, optional
         Directory in which the temporary per-capsule working tree is created.
         When ``None``, the system default temporary location is used.
     test : bool, optional
-        When ``True``, leave the scratch directory on disk after a successful
-        move for debugging.
+        When ``True``, leave the temporary working tree on disk after a
+        successful move for debugging.
 
     Raises
     ------
     RuntimeError
         If ``DANDI_API_KEY`` is unset or blank, or if any ``dandi`` subprocess
-        returns a non-zero exit code. The scratch directory is intentionally
-        left in place when any step fails so that it can be inspected.
+        returns a non-zero exit code. The temporary working tree is
+        intentionally left in place when any step fails so that it can be
+        inspected.
     """
     if not os.environ.get("DANDI_API_KEY", "").strip():
         message = "`DANDI_API_KEY` environment variable is not set or is blank."
@@ -66,13 +67,13 @@ def move_job_capsule(
 
     relative_capsule_path = capsule_path.strip("/")
 
-    scratch_root = pathlib.Path(tempfile.mkdtemp(dir=scratch_directory, prefix="move-capsule-"))
+    processing_root = pathlib.Path(tempfile.mkdtemp(dir=processing_directory, prefix="move-capsule-"))
     _log.info(
         "Moving job capsule %s from %s to %s in %s",
         relative_capsule_path,
         source_dandiset_id,
         target_dandiset_id,
-        scratch_root,
+        processing_root,
     )
 
     source_url = f"dandi://dandi/{source_dandiset_id}/{relative_capsule_path}/"
@@ -80,7 +81,7 @@ def move_job_capsule(
         ["dandi", "download", "--preserve-tree", source_url],
         capture_output=True,
         text=True,
-        cwd=scratch_root,
+        cwd=processing_root,
     )
     _log.info("dandi download returned code %d for %s", download.returncode, source_url)
     _log.debug("dandi download stdout: %s\nstderr: %s", download.stdout, download.stderr)
@@ -94,7 +95,7 @@ def move_job_capsule(
         ["dandi", "download", "--download", "dandiset.yaml", target_url],
         capture_output=True,
         text=True,
-        cwd=scratch_root,
+        cwd=processing_root,
     )
     _log.info("dandi download of dandiset.yaml returned code %d for %s", metadata_download.returncode, target_url)
     _log.debug("dandi download stdout: %s\nstderr: %s", metadata_download.stdout, metadata_download.stderr)
@@ -103,12 +104,12 @@ def move_job_capsule(
         message = f"dandi download of dandiset.yaml failed for {target_url}"
         raise RuntimeError(message)
 
-    source_capsule_directory = scratch_root / source_dandiset_id / relative_capsule_path
-    target_capsule_directory = scratch_root / target_dandiset_id / relative_capsule_path
+    source_capsule_directory = processing_root / source_dandiset_id / relative_capsule_path
+    target_capsule_directory = processing_root / target_dandiset_id / relative_capsule_path
     target_capsule_directory.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source_capsule_directory, target_capsule_directory)
 
-    target_dandiset_directory = scratch_root / target_dandiset_id
+    target_dandiset_directory = processing_root / target_dandiset_id
     upload = subprocess.run(
         ["dandi", "upload", "--allow-any-path", relative_capsule_path],
         capture_output=True,
@@ -138,6 +139,6 @@ def move_job_capsule(
         raise RuntimeError(message)
 
     if test:
-        _log.info("Leaving scratch directory in place for test mode: %s", scratch_root)
+        _log.info("Leaving temporary working tree in place for test mode: %s", processing_root)
     else:
-        shutil.rmtree(scratch_root)
+        shutil.rmtree(processing_root)

--- a/tests/dandi_compute_code/_cli/test_cli_descriptions.py
+++ b/tests/dandi_compute_code/_cli/test_cli_descriptions.py
@@ -25,7 +25,7 @@ from dandi_compute_code._cli import _dandicompute_group
         (["delete", "--help"], "Delete remote and local derivatives for specific version patterns."),
         (["archive", "--help"], "Move job capsules into the permanent archive of failed job runs."),
         (
-            ["archive", "capsule", "--help"],
+            ["archive", "job", "--help"],
             "Move a job capsule from the job capsules Dandiset to the failed runs archive.",
         ),
     ],

--- a/tests/dandi_compute_code/_cli/test_cli_descriptions.py
+++ b/tests/dandi_compute_code/_cli/test_cli_descriptions.py
@@ -23,6 +23,11 @@ from dandi_compute_code._cli import _dandicompute_group
         (["issues", "dump", "--help"], "Scan nextflow and slurm logs and write per-capsule issue records."),
         (["issues", "summarize", "--help"], "Summarize discovered issue lines by descending occurrence count."),
         (["delete", "--help"], "Delete remote and local derivatives for specific version patterns."),
+        (["archive", "--help"], "Move job capsules into the permanent archive of failed job runs."),
+        (
+            ["archive", "capsule", "--help"],
+            "Move a job capsule from the job capsules Dandiset to the failed runs archive.",
+        ),
     ],
 )
 def test_cli_help_includes_descriptions(args: list[str], expected_text: str) -> None:

--- a/tests/dandi_compute_code/dandiset/test_move_job_capsule.py
+++ b/tests/dandi_compute_code/dandiset/test_move_job_capsule.py
@@ -287,4 +287,4 @@ def test_cli_archive_job_invokes_move(tmp_path: pathlib.Path) -> None:
         )
     assert result.exit_code == 0, result.output
     assert "Archived job capsule" in result.output
-    mock_move.assert_called_once_with(capsule_path=_EXAMPLE_CAPSULE_PATH, scratch_directory=None, test=False)
+    mock_move.assert_called_once_with(capsule_path=_EXAMPLE_CAPSULE_PATH, processing_directory=None, test=False)

--- a/tests/dandi_compute_code/dandiset/test_move_job_capsule.py
+++ b/tests/dandi_compute_code/dandiset/test_move_job_capsule.py
@@ -1,0 +1,290 @@
+"""
+Unit tests for move_job_capsule and the ``dandicompute archive capsule`` CLI command.
+"""
+
+import os
+import pathlib
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from dandi_compute_code._cli import _dandicompute_group
+from dandi_compute_code.dandiset import move_job_capsule
+
+_SOURCE_DANDISET_ID = "001697"
+_TARGET_DANDISET_ID = "001873"
+_EXAMPLE_CAPSULE_PATH = (
+    "derivatives/dandiset-000409/sub-mouse01/pipeline-aind+ephys" "/version-v1.0_params-default_config-abc123_attempt-1"
+)
+
+
+def _make_run_side_effect(*, upload_returncode: int = 0):
+    """Build a subprocess.run side effect that materializes the downloaded trees."""
+
+    def _side_effect(command: list, **kwargs: object) -> mock.MagicMock:
+        result = mock.MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        cwd = pathlib.Path(str(kwargs.get("cwd", ".")))
+        if command[:3] == ["dandi", "download", "--preserve-tree"]:
+            url = command[-1]
+            _, relative = url.split(f"/{_SOURCE_DANDISET_ID}/", 1)
+            capsule_dir = cwd / _SOURCE_DANDISET_ID / relative.strip("/")
+            (capsule_dir / "code").mkdir(parents=True, exist_ok=True)
+            (capsule_dir / "code" / "submit.sh").write_text("#!/bin/bash\n")
+            (cwd / _SOURCE_DANDISET_ID / "dandiset.yaml").write_text("identifier: DANDI:001697\n")
+        elif command[:4] == ["dandi", "download", "--download", "dandiset.yaml"]:
+            (cwd / _TARGET_DANDISET_ID).mkdir(parents=True, exist_ok=True)
+            (cwd / _TARGET_DANDISET_ID / "dandiset.yaml").write_text("identifier: DANDI:001873\n")
+        elif command[:2] == ["dandi", "upload"]:
+            result.returncode = upload_returncode
+        return result
+
+    return _side_effect
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_raises_without_dandi_api_key(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule raises RuntimeError when DANDI_API_KEY is not set."""
+    env_without_key = {k: v for k, v in os.environ.items() if k != "DANDI_API_KEY"}
+    with mock.patch.dict(os.environ, env_without_key, clear=True):
+        with pytest.raises(RuntimeError, match="DANDI_API_KEY"):
+            move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH)
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_downloads_source_with_preserve_tree(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule downloads the source capsule with --preserve-tree."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree"),
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH)
+
+    expected_url = f"dandi://dandi/{_SOURCE_DANDISET_ID}/{_EXAMPLE_CAPSULE_PATH}/"
+    download_call = mock_run.call_args_list[0]
+    assert download_call.args[0] == ["dandi", "download", "--preserve-tree", expected_url]
+    assert download_call.kwargs.get("cwd") == scratch
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_downloads_target_dandiset_yaml(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule fetches only the target dandiset.yaml before uploading."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree"),
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH)
+
+    metadata_call = mock_run.call_args_list[1]
+    expected_url = f"dandi://dandi/{_TARGET_DANDISET_ID}/"
+    assert metadata_call.args[0] == ["dandi", "download", "--download", "dandiset.yaml", expected_url]
+    assert metadata_call.kwargs.get("cwd") == scratch
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_copies_capsule_into_target_tree(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule copies the capsule subtree under the target Dandiset tree."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree"),
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH, test=True)
+
+    target_capsule = scratch / _TARGET_DANDISET_ID / _EXAMPLE_CAPSULE_PATH
+    assert (target_capsule / "code" / "submit.sh").is_file()
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_uploads_with_allow_any_path(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule uploads only the capsule subtree from the target Dandiset root."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree"),
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH)
+
+    upload_call = mock_run.call_args_list[2]
+    assert upload_call.args[0] == ["dandi", "upload", "--allow-any-path", _EXAMPLE_CAPSULE_PATH]
+    assert upload_call.kwargs.get("cwd") == scratch / _TARGET_DANDISET_ID
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_deletes_source_after_successful_upload(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule deletes the source capsule only after a successful upload."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree"),
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH)
+
+    delete_call = mock_run.call_args_list[3]
+    expected_source = scratch / _SOURCE_DANDISET_ID / _EXAMPLE_CAPSULE_PATH
+    assert delete_call.args[0] == ["dandi", "delete", str(expected_source)]
+    assert delete_call.kwargs.get("input") == b"y\n"
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_cleans_up_scratch_on_success(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule removes the scratch directory when all steps succeed."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree") as mock_rmtree,
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH)
+
+    mock_rmtree.assert_called_once_with(scratch)
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_preserves_scratch_in_test_mode(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule preserves the scratch directory after success in test mode."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree") as mock_rmtree,
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH, test=True)
+
+    mock_rmtree.assert_not_called()
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_does_not_delete_source_when_upload_fails(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule never deletes the source nor cleans scratch when upload fails."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree") as mock_rmtree,
+    ):
+        mock_run.side_effect = _make_run_side_effect(upload_returncode=1)
+        with pytest.raises(RuntimeError, match="dandi upload failed"):
+            move_job_capsule(capsule_path=_EXAMPLE_CAPSULE_PATH)
+
+    delete_calls = [call for call in mock_run.call_args_list if call.args[0][:2] == ["dandi", "delete"]]
+    assert delete_calls == []
+    mock_rmtree.assert_not_called()
+
+
+@pytest.mark.ai_generated
+def test_move_job_capsule_strips_surrounding_slashes(tmp_path: pathlib.Path) -> None:
+    """move_job_capsule normalizes a path with surrounding slashes."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch(
+            "dandi_compute_code.dandiset._move_job_capsule.tempfile.mkdtemp",
+            return_value=str(scratch),
+        ),
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.subprocess.run") as mock_run,
+        mock.patch("dandi_compute_code.dandiset._move_job_capsule.shutil.rmtree"),
+    ):
+        mock_run.side_effect = _make_run_side_effect()
+        move_job_capsule(capsule_path=f"/{_EXAMPLE_CAPSULE_PATH}/")
+
+    expected_url = f"dandi://dandi/{_SOURCE_DANDISET_ID}/{_EXAMPLE_CAPSULE_PATH}/"
+    assert mock_run.call_args_list[0].args[0][-1] == expected_url
+
+
+@pytest.mark.ai_generated
+def test_cli_archive_capsule_fails_without_api_key(tmp_path: pathlib.Path) -> None:
+    """CLI errors immediately when DANDI_API_KEY is missing."""
+    runner = CliRunner()
+    env_without_key = {k: v for k, v in os.environ.items() if k != "DANDI_API_KEY"}
+    with mock.patch.dict(os.environ, env_without_key, clear=True):
+        result = runner.invoke(
+            _dandicompute_group,
+            ["archive", "capsule", "--path", _EXAMPLE_CAPSULE_PATH],
+        )
+    assert result.exit_code != 0
+    assert "DANDI_API_KEY" in result.output
+
+
+@pytest.mark.ai_generated
+def test_cli_archive_capsule_invokes_move(tmp_path: pathlib.Path) -> None:
+    """dandicompute archive capsule calls move_job_capsule with the provided path."""
+    runner = CliRunner()
+    with (
+        mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
+        mock.patch("dandi_compute_code._cli._dandicompute_group.move_job_capsule") as mock_move,
+    ):
+        result = runner.invoke(
+            _dandicompute_group,
+            ["archive", "capsule", "--path", _EXAMPLE_CAPSULE_PATH],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Archived job capsule" in result.output
+    mock_move.assert_called_once_with(capsule_path=_EXAMPLE_CAPSULE_PATH, scratch_directory=None, test=False)

--- a/tests/dandi_compute_code/dandiset/test_move_job_capsule.py
+++ b/tests/dandi_compute_code/dandiset/test_move_job_capsule.py
@@ -1,5 +1,5 @@
 """
-Unit tests for move_job_capsule and the ``dandicompute archive capsule`` CLI command.
+Unit tests for move_job_capsule and the ``dandicompute archive job`` CLI command.
 """
 
 import os
@@ -260,22 +260,22 @@ def test_move_job_capsule_strips_surrounding_slashes(tmp_path: pathlib.Path) -> 
 
 
 @pytest.mark.ai_generated
-def test_cli_archive_capsule_fails_without_api_key(tmp_path: pathlib.Path) -> None:
+def test_cli_archive_job_fails_without_api_key(tmp_path: pathlib.Path) -> None:
     """CLI errors immediately when DANDI_API_KEY is missing."""
     runner = CliRunner()
     env_without_key = {k: v for k, v in os.environ.items() if k != "DANDI_API_KEY"}
     with mock.patch.dict(os.environ, env_without_key, clear=True):
         result = runner.invoke(
             _dandicompute_group,
-            ["archive", "capsule", "--path", _EXAMPLE_CAPSULE_PATH],
+            ["archive", "job", "--path", _EXAMPLE_CAPSULE_PATH],
         )
     assert result.exit_code != 0
     assert "DANDI_API_KEY" in result.output
 
 
 @pytest.mark.ai_generated
-def test_cli_archive_capsule_invokes_move(tmp_path: pathlib.Path) -> None:
-    """dandicompute archive capsule calls move_job_capsule with the provided path."""
+def test_cli_archive_job_invokes_move(tmp_path: pathlib.Path) -> None:
+    """dandicompute archive job calls move_job_capsule with the provided path."""
     runner = CliRunner()
     with (
         mock.patch.dict(os.environ, {"DANDI_API_KEY": "test-key"}),
@@ -283,7 +283,7 @@ def test_cli_archive_capsule_invokes_move(tmp_path: pathlib.Path) -> None:
     ):
         result = runner.invoke(
             _dandicompute_group,
-            ["archive", "capsule", "--path", _EXAMPLE_CAPSULE_PATH],
+            ["archive", "job", "--path", _EXAMPLE_CAPSULE_PATH],
         )
     assert result.exit_code == 0, result.output
     assert "Archived job capsule" in result.output


### PR DESCRIPTION
## Summary
This PR adds a new `dandicompute archive capsule` CLI command that moves job capsule folders from the job capsules Dandiset (001697) to a permanent archive Dandiset (001873) for failed runs.

## Key Changes
- **New `move_job_capsule()` function** (`src/dandi_compute_code/dandiset/_move_job_capsule.py`):
  - Downloads a capsule subtree from source Dandiset using `dandi download --preserve-tree`
  - Fetches target Dandiset metadata
  - Copies the capsule into the target Dandiset tree
  - Uploads via `dandi upload --allow-any-path`
  - Deletes from source only after successful upload
  - Cleans up scratch directory on success (unless in test mode)
  - Preserves scratch directory on failure for debugging

- **New CLI command** (`dandicompute archive capsule`):
  - Accepts `--path` (required) for the capsule path relative to Dandiset root
  - Accepts `--scratch` (optional) for custom temporary directory location
  - Accepts `--test` flag to preserve scratch directory for debugging
  - Accepts `--silent` flag to suppress informational output
  - Requires `DANDI_API_KEY` environment variable

- **Global constants** added to `_globals.py`:
  - `_JOB_CAPSULES_DANDISET_ID = "001697"`
  - `_FAILED_RUNS_ARCHIVE_DANDISET_ID = "001873"`

- **Comprehensive test suite** (290 lines):
  - Tests for API key validation
  - Tests for download with `--preserve-tree`
  - Tests for target metadata download
  - Tests for capsule copying and uploading
  - Tests for source deletion after successful upload
  - Tests for scratch directory cleanup
  - Tests for failure handling (no deletion/cleanup on upload failure)
  - Tests for path normalization
  - CLI integration tests

## Implementation Details
- The operation is atomic with respect to the source: deletion only occurs after successful upload
- Failed uploads never destroy the original capsule
- Scratch directory is intentionally preserved on any failure for inspection
- All subprocess calls use `capture_output=True` for proper logging
- Path normalization strips surrounding slashes for consistency

https://claude.ai/code/session_01Hrte6VSaHX52WQtpWcKCW2