### PR TITLE
Remove internal function assignments from CLI group

### DIFF
--- a/src/dandi_compute_code/_cli/_dandicompute_group.py
+++ b/src/dandi_compute_code/_cli/_dandicompute_group.py
@@ -681,15 +681,3 @@ def _delete_version_command(dandiset_directory: pathlib.Path, version: str, sile
     deleted = delete_dandiset_version(dandiset_directory=dandiset_directory, version=version)
     if not silent:
         _styled_echo(text=f"\nDeleted {len(deleted)} version {noun}.", color="green")
-
-
-# Required for daily tests
-_dandicompute_group.prepare_queue = prepare_queue
-_dandicompute_group.prepare_aind_ephys_job = prepare_aind_ephys_job
-_dandicompute_group.clean_unsubmitted_capsules = clean_unsubmitted_capsules
-_dandicompute_group.aggregate_queue_statistics = aggregate_queue_statistics
-_dandicompute_group.dump_issues = dump_issues
-_dandicompute_group.summarize_issues = summarize_issues
-_dandicompute_group.process_queue = process_queue
-_dandicompute_group.has_pending_jobs = has_pending_jobs
-_dandicompute_group.write_queue_state = write_queue_state


### PR DESCRIPTION
## Summary
Removed internal function assignments that were appended to the `_dandicompute_group` CLI group object. These assignments were previously added to expose internal functions for daily testing purposes.

## Changes
- Removed 9 function assignments that were attaching internal functions to the `_dandicompute_group` object:
  - `prepare_queue`
  - `prepare_aind_ephys_job`
  - `clean_unsubmitted_capsules`
  - `aggregate_queue_statistics`
  - `dump_issues`
  - `summarize_issues`
  - `process_queue`
  - `has_pending_jobs`
  - `write_queue_state`

## Rationale
These assignments were marked as "Required for daily tests" but appear to be an anti-pattern for exposing internal functionality. This change likely reflects a shift to a cleaner testing approach that doesn't rely on monkey-patching the CLI group object with internal functions.

https://claude.ai/code/session_017CL5KMYvWkeCjYuQuv4HKe