### PR TITLE
Add soft-rollout failsafe for QueueState OOP model migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.45"
+version = "0.3.46"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/_cli/_dandicompute_group.py
+++ b/src/dandi_compute_code/_cli/_dandicompute_group.py
@@ -5,6 +5,7 @@ import pathlib
 import click
 
 from ._clean_work_directory import clean_work_directory
+from ._oop_failsafe import run_with_oop_failsafe
 from ._styled_echo import _styled_echo
 from .._configure_logging import _configure_logging
 from ..aind_ephys_pipeline import prepare_aind_ephys_job, submit_job
@@ -15,6 +16,7 @@ from ..dandiset import (
 )
 from ..queue import (
     TEST_QUEUE_CONTENT_ID,
+    QueueState,
     aggregate_queue_statistics,
     clean_unsubmitted_capsules,
     dump_issues,
@@ -224,11 +226,27 @@ def _prepare_aind_command(
     if test:
         if queue_directory is None:
             raise click.UsageError("--queue is required when using --test.")
-        prepare_queue(
-            queue_directory=queue_directory,
-            content_ids=[TEST_QUEUE_CONTENT_ID],
-            pipeline_directory=pipeline_directory,
-            config_key=config_key,
+
+        def _prepare_test_oop() -> None:
+            QueueState.prepare(
+                queue_directory=queue_directory,
+                content_ids=[TEST_QUEUE_CONTENT_ID],
+                pipeline_directory=pipeline_directory,
+                config_key=config_key,
+            )
+
+        def _prepare_test_fallback() -> None:
+            prepare_queue(
+                queue_directory=queue_directory,
+                content_ids=[TEST_QUEUE_CONTENT_ID],
+                pipeline_directory=pipeline_directory,
+                config_key=config_key,
+            )
+
+        run_with_oop_failsafe(
+            command="prepare aind --test",
+            oop_path=_prepare_test_oop,
+            fallback_path=_prepare_test_fallback,
         )
         return
 
@@ -293,9 +311,17 @@ def _queue_refresh_command(
 ) -> None:
     """Regenerate state.jsonl and archive_state.jsonl from DANDI assets metadata."""
     _configure_logging(silent=silent)
-    try:
+
+    def _refresh_oop() -> None:
+        QueueState.write_state(queue_directory=queue_directory)
+        QueueState.write_archive_state(queue_directory=queue_directory)
+
+    def _refresh_fallback() -> None:
         write_queue_state(queue_directory=queue_directory)
         write_archive_state(queue_directory=queue_directory)
+
+    try:
+        run_with_oop_failsafe(command="queue refresh", oop_path=_refresh_oop, fallback_path=_refresh_fallback)
     except FileNotFoundError as error:
         raise click.ClickException(str(error)) from error
 
@@ -331,7 +357,15 @@ def _queue_clean_command(
     """Delete unsubmitted capsules that are no longer present in the queue."""
     _configure_logging(silent=silent)
     _require_dandi_api_key()
-    removed = clean_unsubmitted_capsules(dandiset_directory=dandiset_directory, queue_directory=queue_directory)
+
+    def _clean_oop() -> list[pathlib.Path]:
+        state = QueueState.from_jsonl(queue_directory / "state.jsonl")
+        return state.clean_unsubmitted_capsules(dandiset_directory=dandiset_directory)
+
+    def _clean_fallback() -> list[pathlib.Path]:
+        return clean_unsubmitted_capsules(dandiset_directory=dandiset_directory, queue_directory=queue_directory)
+
+    removed = run_with_oop_failsafe(command="queue clean", oop_path=_clean_oop, fallback_path=_clean_fallback)
     if removed:
         if not silent:
             for path in removed:
@@ -382,11 +416,23 @@ def _queue_stats_command(
 ) -> None:
     """Write aggregate queue statistics from state.jsonl and timeline reports."""
     _configure_logging(silent=silent)
-    aggregate_queue_statistics(
-        queue_directory=queue_directory,
-        dandiset_directory=dandiset_directory,
-        output_file_name=output_file_name,
-    )
+
+    def _stats_oop() -> dict:
+        state = QueueState.from_jsonl(queue_directory / "state.jsonl")
+        return state.aggregate_statistics(
+            queue_directory=queue_directory,
+            dandiset_directory=dandiset_directory,
+            output_file_name=output_file_name,
+        )
+
+    def _stats_fallback() -> dict:
+        return aggregate_queue_statistics(
+            queue_directory=queue_directory,
+            dandiset_directory=dandiset_directory,
+            output_file_name=output_file_name,
+        )
+
+    run_with_oop_failsafe(command="queue stats", oop_path=_stats_oop, fallback_path=_stats_fallback)
     if not silent:
         _styled_echo(text=f"\nWrote queue aggregate statistics: {queue_directory / output_file_name}", color="green")
 
@@ -411,7 +457,11 @@ def _queue_pending_command(context: click.Context, silent: bool = False) -> None
         dandicompute queue pending --silent && dandicompute queue process ...
     """
     _configure_logging(silent=silent)
-    pending = has_pending_jobs()
+    pending = run_with_oop_failsafe(
+        command="queue pending",
+        oop_path=QueueState.has_pending_jobs,
+        fallback_path=has_pending_jobs,
+    )
     if not silent:
         _styled_echo(text="true" if pending else "false", color="green" if pending else "yellow")
     context.exit(0 if pending else 1)
@@ -478,12 +528,29 @@ def _queue_process_command(
     _configure_logging(silent=silent)
     _require_dandi_api_key()
     _require_dandi_devel()
-    queue_status = process_queue(
-        queue_directory=queue_directory,
-        processing_directory=processing_directory,
-        max_concurrent_aind_jobs=max_concurrent_aind_jobs,
-        jitter_seconds=jitter_seconds,
-        test=test,
+
+    def _process_oop() -> str:
+        return QueueState.process_queue(
+            queue_directory=queue_directory,
+            processing_directory=processing_directory,
+            max_concurrent_aind_jobs=max_concurrent_aind_jobs,
+            jitter_seconds=jitter_seconds,
+            test=test,
+        )
+
+    def _process_fallback() -> str:
+        return process_queue(
+            queue_directory=queue_directory,
+            processing_directory=processing_directory,
+            max_concurrent_aind_jobs=max_concurrent_aind_jobs,
+            jitter_seconds=jitter_seconds,
+            test=test,
+        )
+
+    queue_status = run_with_oop_failsafe(
+        command="queue process",
+        oop_path=_process_oop,
+        fallback_path=_process_fallback,
     )
     if not silent and queue_status == "no-pending":
         _styled_echo(text="\nNo jobs were found waiting to be submitted.", color="yellow")
@@ -540,12 +607,24 @@ def _queue_prepare_command(
     _configure_logging(silent=silent)
     if "DANDI_API_KEY" not in os.environ:
         raise click.ClickException("`DANDI_API_KEY` environment variable is not set.")
-    prepare_queue(
-        queue_directory=queue_directory,
-        pipeline_directory=pipeline_directory,
-        config_key=config_key,
-        limit=limit,
-    )
+
+    def _prepare_oop() -> None:
+        QueueState.prepare(
+            queue_directory=queue_directory,
+            pipeline_directory=pipeline_directory,
+            config_key=config_key,
+            limit=limit,
+        )
+
+    def _prepare_fallback() -> None:
+        prepare_queue(
+            queue_directory=queue_directory,
+            pipeline_directory=pipeline_directory,
+            config_key=config_key,
+            limit=limit,
+        )
+
+    run_with_oop_failsafe(command="queue prepare", oop_path=_prepare_oop, fallback_path=_prepare_fallback)
 
 
 # dandicompute issues
@@ -585,7 +664,14 @@ def _issues_dump_command(
 ) -> None:
     """Scan nextflow and slurm logs and write per-capsule issue records."""
     _configure_logging(silent=silent)
-    dump_issues(dandiset_directory=dandiset_directory, queue_directory=queue_directory)
+
+    def _dump_oop() -> list[dict]:
+        return QueueState.dump_issues(dandiset_directory=dandiset_directory, queue_directory=queue_directory)
+
+    def _dump_fallback() -> list[dict]:
+        return dump_issues(dandiset_directory=dandiset_directory, queue_directory=queue_directory)
+
+    run_with_oop_failsafe(command="issues dump", oop_path=_dump_oop, fallback_path=_dump_fallback)
     if not silent:
         _styled_echo(text=f"\nWrote issue dump: {queue_directory / 'issues_dump.json'}", color="green")
 
@@ -620,7 +706,14 @@ def _issues_summarize_command(
 ) -> None:
     """Summarize discovered issue lines by descending occurrence count."""
     _configure_logging(silent=silent)
-    summarize_issues(dandiset_directory=dandiset_directory, queue_directory=queue_directory)
+
+    def _summarize_oop() -> dict[str, list[str]]:
+        return QueueState.summarize_issues(dandiset_directory=dandiset_directory, queue_directory=queue_directory)
+
+    def _summarize_fallback() -> dict[str, list[str]]:
+        return summarize_issues(dandiset_directory=dandiset_directory, queue_directory=queue_directory)
+
+    run_with_oop_failsafe(command="issues summarize", oop_path=_summarize_oop, fallback_path=_summarize_fallback)
     if not silent:
         _styled_echo(text=f"\nWrote issue summary: {queue_directory / 'issues_summary.json'}", color="green")
 

--- a/src/dandi_compute_code/_cli/_oop_failsafe.py
+++ b/src/dandi_compute_code/_cli/_oop_failsafe.py
@@ -25,8 +25,19 @@ _ResultT = TypeVar("_ResultT")
 #: Environment variable that overrides the failsafe log location.
 _OOP_FAILSAFE_LOG_ENV_VAR = "DANDICOMPUTE_OOP_FAILSAFE_LOG"
 
+#: Environment variable kill-switch that disables the new OOP path entirely.
+_OOP_DISABLE_ENV_VAR = "DANDICOMPUTE_DISABLE_OOP"
+
 #: Default failsafe log file used when the override variable is unset.
 _DEFAULT_OOP_FAILSAFE_LOG = pathlib.Path.home() / ".dandicompute" / "oop_failsafe.jsonl"
+
+#: Values of the kill-switch variable that count as "disabled".
+_TRUTHY_DISABLE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _oop_path_is_disabled() -> bool:
+    """Report whether the OOP kill-switch environment variable is set to a truthy value."""
+    return os.environ.get(_OOP_DISABLE_ENV_VAR, "").strip().lower() in _TRUTHY_DISABLE_VALUES
 
 
 def _resolve_oop_failsafe_log_path() -> pathlib.Path:
@@ -70,6 +81,11 @@ def run_with_oop_failsafe(
     *fallback_path* is invoked to preserve the current runtime behavior. The
     result of whichever path completes is returned.
 
+    The OOP path can be disabled outright for the duration of the soft rollout by
+    setting the ``DANDICOMPUTE_DISABLE_OOP`` environment variable to a truthy
+    value (``1``, ``true``, ``yes``, or ``on``); the command then runs
+    *fallback_path* directly without attempting (or logging) the OOP path.
+
     Parameters
     ----------
     command : str
@@ -80,6 +96,10 @@ def run_with_oop_failsafe(
     fallback_path : callable
         Zero-argument callable invoking the current free-function behavior.
     """
+    if _oop_path_is_disabled():
+        _log.info("OOP path disabled via %s; running current behavior for '%s'.", _OOP_DISABLE_ENV_VAR, command)
+        return fallback_path()
+
     try:
         oop_result = oop_path()
         return oop_result

--- a/src/dandi_compute_code/_cli/_oop_failsafe.py
+++ b/src/dandi_compute_code/_cli/_oop_failsafe.py
@@ -1,0 +1,90 @@
+"""
+Soft-rollout failsafe for the new ``QueueState`` OOP model.
+
+Each queue-related CLI command first attempts the new OOP code path. If that
+path raises for any reason, the failure is recorded to a failsafe log file (so
+it can be investigated and fixed later) and the command falls back to the
+current free-function runtime behavior. This keeps the rollout safe: a defect in
+the new model never regresses a user-facing command, but every divergence is
+captured for follow-up.
+"""
+
+import datetime
+import json
+import logging
+import os
+import pathlib
+import traceback
+from collections.abc import Callable
+from typing import TypeVar
+
+_log = logging.getLogger(__name__)
+
+_ResultT = TypeVar("_ResultT")
+
+#: Environment variable that overrides the failsafe log location.
+_OOP_FAILSAFE_LOG_ENV_VAR = "DANDICOMPUTE_OOP_FAILSAFE_LOG"
+
+#: Default failsafe log file used when the override variable is unset.
+_DEFAULT_OOP_FAILSAFE_LOG = pathlib.Path.home() / ".dandicompute" / "oop_failsafe.jsonl"
+
+
+def _resolve_oop_failsafe_log_path() -> pathlib.Path:
+    """Resolve the failsafe log path, honoring the override environment variable."""
+    override = os.environ.get(_OOP_FAILSAFE_LOG_ENV_VAR, "").strip()
+    log_path = pathlib.Path(override) if override else _DEFAULT_OOP_FAILSAFE_LOG
+    return log_path
+
+
+def _record_oop_failure(*, command: str, error: BaseException) -> None:
+    """Append a structured record of an OOP-path failure to the failsafe log file."""
+    formatted_traceback = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    record = {
+        "logged_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "command": command,
+        "error_type": type(error).__name__,
+        "error_message": str(error),
+        "traceback": formatted_traceback,
+    }
+
+    log_path = _resolve_oop_failsafe_log_path()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open(mode="a") as log_stream:
+            log_stream.write(json.dumps(record) + "\n")
+    except OSError as log_error:
+        _log.warning("Could not write OOP failsafe log to %s: %s", log_path, log_error)
+
+
+def run_with_oop_failsafe(
+    *,
+    command: str,
+    oop_path: Callable[[], _ResultT],
+    fallback_path: Callable[[], _ResultT],
+) -> _ResultT:
+    """
+    Attempt the new OOP ``QueueState`` code path, falling back to current behavior.
+
+    The *oop_path* callable is attempted first. If it raises any exception, the
+    failure is recorded to the failsafe log file for later investigation and
+    *fallback_path* is invoked to preserve the current runtime behavior. The
+    result of whichever path completes is returned.
+
+    Parameters
+    ----------
+    command : str
+        Human-readable command label recorded with any failure (e.g. ``"queue
+        process"``).
+    oop_path : callable
+        Zero-argument callable invoking the new ``QueueState`` model.
+    fallback_path : callable
+        Zero-argument callable invoking the current free-function behavior.
+    """
+    try:
+        oop_result = oop_path()
+        return oop_result
+    except Exception as error:
+        _record_oop_failure(command=command, error=error)
+        _log.warning("OOP path for '%s' failed; falling back to current behavior (%s).", command, error)
+        fallback_result = fallback_path()
+        return fallback_result

--- a/tests/dandi_compute_code/_cli/test_cli_oop_failsafe.py
+++ b/tests/dandi_compute_code/_cli/test_cli_oop_failsafe.py
@@ -104,6 +104,66 @@ def test_oop_success_skips_fallback_and_does_not_log(tmp_path: pathlib.Path, fai
 
 
 @pytest.mark.ai_generated
+@pytest.mark.parametrize("disable_value", ["1", "true", "yes", "on", "TRUE"])
+def test_kill_switch_skips_oop_and_runs_fallback(
+    tmp_path: pathlib.Path, failsafe_log: pathlib.Path, disable_value: str
+) -> None:
+    """The kill-switch env var bypasses the OOP path without attempting or logging it."""
+    queue_dir = _make_queue_dir(tmp_path)
+    processing_dir = tmp_path / "processing"
+    processing_dir.mkdir()
+    runner = CliRunner()
+
+    with (
+        mock.patch(f"{_GROUP}.QueueState.process_queue") as mock_oop,
+        mock.patch(f"{_GROUP}.process_queue", return_value="submitted") as mock_fallback,
+    ):
+        result = runner.invoke(
+            _dandicompute_group,
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir)],
+            env={
+                "DANDI_API_KEY": "test-key",
+                "DANDI_DEVEL": "1",
+                "DANDICOMPUTE_DISABLE_OOP": disable_value,
+                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log),
+            },
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_oop.assert_not_called()
+    mock_fallback.assert_called_once()
+    assert not failsafe_log.exists()
+
+
+@pytest.mark.ai_generated
+def test_kill_switch_unset_still_attempts_oop(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
+    """A blank or absent kill-switch leaves the OOP path as the primary route."""
+    queue_dir = _make_queue_dir(tmp_path)
+    processing_dir = tmp_path / "processing"
+    processing_dir.mkdir()
+    runner = CliRunner()
+
+    with (
+        mock.patch(f"{_GROUP}.QueueState.process_queue", return_value="submitted") as mock_oop,
+        mock.patch(f"{_GROUP}.process_queue") as mock_fallback,
+    ):
+        result = runner.invoke(
+            _dandicompute_group,
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir)],
+            env={
+                "DANDI_API_KEY": "test-key",
+                "DANDI_DEVEL": "1",
+                "DANDICOMPUTE_DISABLE_OOP": "",
+                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log),
+            },
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_oop.assert_called_once()
+    mock_fallback.assert_not_called()
+
+
+@pytest.mark.ai_generated
 def test_failure_log_appends_across_invocations(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
     """Repeated OOP failures append, leaving an investigable record per invocation."""
     runner = CliRunner()

--- a/tests/dandi_compute_code/_cli/test_cli_oop_failsafe.py
+++ b/tests/dandi_compute_code/_cli/test_cli_oop_failsafe.py
@@ -1,0 +1,176 @@
+"""
+Tests for the soft-rollout failsafe shared by the queue CLI commands.
+
+Each command first attempts the new ``QueueState`` OOP model and, on any failure,
+records the failure to a log file and falls back to the current free-function
+behavior. These tests drive that path through the public CLI surface.
+"""
+
+import json
+import pathlib
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from dandi_compute_code._cli import _dandicompute_group
+
+_GROUP = "dandi_compute_code._cli._dandicompute_group"
+
+
+@pytest.fixture
+def failsafe_log(tmp_path: pathlib.Path) -> pathlib.Path:
+    """A temporary failsafe log path wired through the override environment variable."""
+    return tmp_path / "oop_failsafe.jsonl"
+
+
+def _make_queue_dir(tmp_path: pathlib.Path) -> pathlib.Path:
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    (queue_dir / "queue_config.json").write_text(
+        json.dumps({"pipelines": {"test": {"version_priority": ["v1.0"], "params_priority": ["default"]}}})
+    )
+    return queue_dir
+
+
+@pytest.mark.ai_generated
+def test_oop_failure_falls_back_and_logs(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
+    """When the OOP path raises, the command logs the failure and runs the fallback."""
+    queue_dir = _make_queue_dir(tmp_path)
+    processing_dir = tmp_path / "processing"
+    processing_dir.mkdir()
+    runner = CliRunner()
+
+    with (
+        mock.patch(f"{_GROUP}.QueueState.process_queue", side_effect=RuntimeError("boom")) as mock_oop,
+        mock.patch(f"{_GROUP}.process_queue", return_value="submitted") as mock_fallback,
+    ):
+        result = runner.invoke(
+            _dandicompute_group,
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir)],
+            env={
+                "DANDI_API_KEY": "test-key",
+                "DANDI_DEVEL": "1",
+                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log),
+            },
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_oop.assert_called_once()
+    mock_fallback.assert_called_once_with(
+        queue_directory=queue_dir,
+        processing_directory=processing_dir,
+        max_concurrent_aind_jobs=2,
+        jitter_seconds=30.0,
+        test=False,
+    )
+
+    assert failsafe_log.exists()
+    records = [json.loads(line) for line in failsafe_log.read_text().splitlines() if line.strip()]
+    assert len(records) == 1
+    assert records[0]["command"] == "queue process"
+    assert records[0]["error_type"] == "RuntimeError"
+    assert records[0]["error_message"] == "boom"
+    assert "RuntimeError: boom" in records[0]["traceback"]
+    assert records[0]["logged_at"]
+
+
+@pytest.mark.ai_generated
+def test_oop_success_skips_fallback_and_does_not_log(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
+    """When the OOP path succeeds, the fallback is not used and nothing is logged."""
+    queue_dir = _make_queue_dir(tmp_path)
+    processing_dir = tmp_path / "processing"
+    processing_dir.mkdir()
+    runner = CliRunner()
+
+    with (
+        mock.patch(f"{_GROUP}.QueueState.process_queue", return_value="submitted") as mock_oop,
+        mock.patch(f"{_GROUP}.process_queue") as mock_fallback,
+    ):
+        result = runner.invoke(
+            _dandicompute_group,
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir)],
+            env={
+                "DANDI_API_KEY": "test-key",
+                "DANDI_DEVEL": "1",
+                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log),
+            },
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_oop.assert_called_once()
+    mock_fallback.assert_not_called()
+    assert not failsafe_log.exists()
+
+
+@pytest.mark.ai_generated
+def test_failure_log_appends_across_invocations(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
+    """Repeated OOP failures append, leaving an investigable record per invocation."""
+    runner = CliRunner()
+    env = {"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log)}
+
+    for _ in range(2):
+        with (
+            mock.patch(f"{_GROUP}.QueueState.has_pending_jobs", side_effect=ValueError("nope")),
+            mock.patch(f"{_GROUP}.has_pending_jobs", return_value=True),
+        ):
+            result = runner.invoke(_dandicompute_group, ["queue", "pending"], env=env)
+        assert result.exit_code == 0, result.output
+
+    records = [json.loads(line) for line in failsafe_log.read_text().splitlines() if line.strip()]
+    assert len(records) == 2
+    assert all(record["command"] == "queue pending" for record in records)
+    assert all(record["error_type"] == "ValueError" for record in records)
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    ("command", "oop_target", "fallback_target", "expected_command_label"),
+    [
+        pytest.param("queue pending", "QueueState.has_pending_jobs", "has_pending_jobs", "queue pending", id="pending"),
+        pytest.param("issues dump", "QueueState.dump_issues", "dump_issues", "issues dump", id="issues-dump"),
+        pytest.param(
+            "issues summarize",
+            "QueueState.summarize_issues",
+            "summarize_issues",
+            "issues summarize",
+            id="issues-summarize",
+        ),
+    ],
+)
+def test_each_command_records_its_own_label(
+    tmp_path: pathlib.Path,
+    failsafe_log: pathlib.Path,
+    command: str,
+    oop_target: str,
+    fallback_target: str,
+    expected_command_label: str,
+) -> None:
+    """Every wrapped command falls back on OOP failure and logs under its own label."""
+    queue_dir = _make_queue_dir(tmp_path)
+    dandiset_dir = tmp_path / "dandiset"
+    dandiset_dir.mkdir()
+    runner = CliRunner()
+
+    args_by_command = {
+        "queue pending": ["queue", "pending"],
+        "issues dump": ["issues", "dump", "--directory", str(dandiset_dir), "--queue", str(queue_dir)],
+        "issues summarize": ["issues", "summarize", "--directory", str(dandiset_dir), "--queue", str(queue_dir)],
+    }
+    fallback_returns = {"queue pending": True, "issues dump": [], "issues summarize": {}}
+
+    with (
+        mock.patch(f"{_GROUP}.{oop_target}", side_effect=RuntimeError("boom")),
+        mock.patch(f"{_GROUP}.{fallback_target}", return_value=fallback_returns[command]) as mock_fallback,
+    ):
+        result = runner.invoke(
+            _dandicompute_group,
+            args_by_command[command],
+            env={"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log)},
+        )
+
+    assert result.exit_code in (0, 1), result.output
+    mock_fallback.assert_called_once()
+    records = [json.loads(line) for line in failsafe_log.read_text().splitlines() if line.strip()]
+    assert len(records) == 1
+    assert records[0]["command"] == expected_command_label

--- a/tests/dandi_compute_code/queue/conftest.py
+++ b/tests/dandi_compute_code/queue/conftest.py
@@ -49,7 +49,20 @@ def mock_dandi_assets_metadata() -> Iterator[None]:
             "dandi_compute_code.queue._write_queue_state._load_upstream_assets_jsonld_metadata",
             return_value=empty_metadata,
         ),
+        mock.patch("dandi_compute_code.queue._queue_state.load_assets_jsonld_metadata", return_value=empty_metadata),
+        mock.patch(
+            "dandi_compute_code.queue._queue_utils._load_upstream_assets_jsonld_metadata",
+            return_value=empty_metadata,
+        ),
     ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def redirect_oop_failsafe_log(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    """Redirect the OOP-failsafe log to a temporary file so tests never write under ``$HOME``."""
+    log_path = tmp_path_factory.mktemp("oop_failsafe") / "oop_failsafe.jsonl"
+    with mock.patch.dict(os.environ, {"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(log_path)}):
         yield
 
 

--- a/tests/dandi_compute_code/queue/test_cli_queue_commands.py
+++ b/tests/dandi_compute_code/queue/test_cli_queue_commands.py
@@ -8,8 +8,13 @@ from click.testing import CliRunner
 from dandi_compute_code._cli import _dandicompute_group
 from dandi_compute_code.queue import TEST_QUEUE_CONTENT_ID
 
-# These tests exercise CLI argument wiring; each command's implementation is mocked
-# so only the delegation (option parsing and forwarded kwargs) is under test.
+# These tests exercise CLI argument wiring. Each command first attempts the new
+# OOP ``QueueState`` model (see ``_oop_failsafe``); the model methods are mocked
+# here so only the delegation (option parsing and forwarded kwargs) is under
+# test. Fallback-to-current-behavior and failure logging are covered separately
+# in ``test_cli_oop_failsafe.py``.
+
+_GROUP = "dandi_compute_code._cli._dandicompute_group"
 
 
 def _make_queue_dir(tmp_path: pathlib.Path) -> pathlib.Path:
@@ -23,37 +28,39 @@ def _make_queue_dir(tmp_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.mark.ai_generated
-def test_cli_prepare_test_calls_prepare_queue_with_test_content_id(tmp_path: pathlib.Path) -> None:
-    """dandicompute prepare aind --test calls prepare_queue with the known test content ID."""
+def test_cli_prepare_test_calls_prepare_with_test_content_id(tmp_path: pathlib.Path) -> None:
+    """dandicompute prepare aind --test calls QueueState.prepare with the known test content ID."""
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
     runner = CliRunner()
 
     with (
         mock.patch.dict("os.environ", {"DANDI_API_KEY": "test-key"}),
-        mock.patch("dandi_compute_code._cli._dandicompute_group.prepare_queue") as mock_prepare_queue,
+        mock.patch(f"{_GROUP}.QueueState.prepare") as mock_prepare,
+        mock.patch(f"{_GROUP}.prepare_queue") as mock_prepare_queue,
     ):
         result = runner.invoke(_dandicompute_group, ["prepare", "aind", "--test", "--queue", str(queue_dir)])
 
     assert result.exit_code == 0
-    mock_prepare_queue.assert_called_once_with(
+    mock_prepare.assert_called_once_with(
         queue_directory=queue_dir,
         content_ids=[TEST_QUEUE_CONTENT_ID],
         pipeline_directory=None,
         config_key="default",
     )
+    mock_prepare_queue.assert_not_called()
 
 
 @pytest.mark.ai_generated
 def test_cli_prepare_test_passes_config_key(tmp_path: pathlib.Path) -> None:
-    """dandicompute prepare aind --test forwards --config to prepare_queue."""
+    """dandicompute prepare aind --test forwards --config to QueueState.prepare."""
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
     runner = CliRunner()
 
     with (
         mock.patch.dict("os.environ", {"DANDI_API_KEY": "test-key"}),
-        mock.patch("dandi_compute_code._cli._dandicompute_group.prepare_queue") as mock_prepare_queue,
+        mock.patch(f"{_GROUP}.QueueState.prepare") as mock_prepare,
     ):
         result = runner.invoke(
             _dandicompute_group,
@@ -61,7 +68,7 @@ def test_cli_prepare_test_passes_config_key(tmp_path: pathlib.Path) -> None:
         )
 
     assert result.exit_code == 0
-    mock_prepare_queue.assert_called_once_with(
+    mock_prepare.assert_called_once_with(
         queue_directory=queue_dir,
         content_ids=[TEST_QUEUE_CONTENT_ID],
         pipeline_directory=None,
@@ -86,7 +93,7 @@ def test_cli_aind_prepare_passes_config_key() -> None:
 
     with (
         mock.patch.dict("os.environ", {"DANDI_API_KEY": "test-key"}),
-        mock.patch("dandi_compute_code._cli._dandicompute_group.prepare_aind_ephys_job") as mock_prepare,
+        mock.patch(f"{_GROUP}.prepare_aind_ephys_job") as mock_prepare,
     ):
         mock_prepare.return_value = pathlib.Path("/tmp/submit.sh")
         result = runner.invoke(
@@ -109,33 +116,31 @@ def test_cli_aind_prepare_passes_config_key() -> None:
 
 @pytest.mark.ai_generated
 def test_cli_queue_clean_calls_helper(tmp_path: pathlib.Path) -> None:
-    """dandicompute queue clean delegates to clean_unsubmitted_capsules and reports removed paths."""
+    """dandicompute queue clean delegates to QueueState and reports removed paths."""
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
     dandiset_dir = tmp_path / "dandiset"
     dandiset_dir.mkdir()
 
     fake_removed = [dandiset_dir / "derivatives" / "dandiset-000001" / "sub-mouse01" / "attempt-1"]
+    mock_state = mock.Mock()
+    mock_state.clean_unsubmitted_capsules.return_value = fake_removed
     runner = CliRunner()
 
-    with mock.patch(
-        "dandi_compute_code._cli._dandicompute_group.clean_unsubmitted_capsules", return_value=fake_removed
-    ) as mock_clean:
+    with (
+        mock.patch(f"{_GROUP}.QueueState.from_jsonl", return_value=mock_state) as mock_from_jsonl,
+        mock.patch(f"{_GROUP}.clean_unsubmitted_capsules") as mock_clean,
+    ):
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "clean",
-                "--queue",
-                str(queue_dir),
-                "--dandiset",
-                str(dandiset_dir),
-            ],
+            ["queue", "clean", "--queue", str(queue_dir), "--dandiset", str(dandiset_dir)],
             env={"DANDI_API_KEY": "test-key"},
         )
 
     assert result.exit_code == 0, result.output
-    mock_clean.assert_called_once_with(dandiset_directory=dandiset_dir, queue_directory=queue_dir)
+    mock_from_jsonl.assert_called_once_with(queue_dir / "state.jsonl")
+    mock_state.clean_unsubmitted_capsules.assert_called_once_with(dandiset_directory=dandiset_dir)
+    mock_clean.assert_not_called()
     assert "Cleaned 1 unsubmitted capsule" in result.output
 
 
@@ -147,19 +152,14 @@ def test_cli_queue_clean_reports_nothing_found(tmp_path: pathlib.Path) -> None:
     dandiset_dir = tmp_path / "dandiset"
     dandiset_dir.mkdir()
 
+    mock_state = mock.Mock()
+    mock_state.clean_unsubmitted_capsules.return_value = []
     runner = CliRunner()
 
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.clean_unsubmitted_capsules", return_value=[]):
+    with mock.patch(f"{_GROUP}.QueueState.from_jsonl", return_value=mock_state):
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "clean",
-                "--queue",
-                str(queue_dir),
-                "--dandiset",
-                str(dandiset_dir),
-            ],
+            ["queue", "clean", "--queue", str(queue_dir), "--dandiset", str(dandiset_dir)],
             env={"DANDI_API_KEY": "test-key"},
         )
 
@@ -169,89 +169,80 @@ def test_cli_queue_clean_reports_nothing_found(tmp_path: pathlib.Path) -> None:
 
 @pytest.mark.ai_generated
 def test_cli_queue_stats_calls_helper_and_reports_output(tmp_path: pathlib.Path) -> None:
-    """dandicompute queue stats delegates to aggregate_queue_statistics."""
+    """dandicompute queue stats delegates to QueueState.aggregate_statistics."""
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
     dandiset_dir = tmp_path / "dandiset"
     dandiset_dir.mkdir()
 
+    mock_state = mock.Mock()
+    mock_state.aggregate_statistics.return_value = {"successful_asset_bytes_total": 0}
     runner = CliRunner()
-    with mock.patch(
-        "dandi_compute_code._cli._dandicompute_group.aggregate_queue_statistics",
-        return_value={"successful_asset_bytes_total": 0},
-    ) as mock_stats:
+
+    with (
+        mock.patch(f"{_GROUP}.QueueState.from_jsonl", return_value=mock_state),
+        mock.patch(f"{_GROUP}.aggregate_queue_statistics") as mock_stats,
+    ):
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "stats",
-                "--queue",
-                str(queue_dir),
-                "--dandiset",
-                str(dandiset_dir),
-            ],
+            ["queue", "stats", "--queue", str(queue_dir), "--dandiset", str(dandiset_dir)],
         )
 
     assert result.exit_code == 0, result.output
-    mock_stats.assert_called_once_with(
+    mock_state.aggregate_statistics.assert_called_once_with(
         queue_directory=queue_dir,
         dandiset_directory=dandiset_dir,
         output_file_name="queue_stats.json",
     )
+    mock_stats.assert_not_called()
     assert "Wrote queue aggregate statistics" in result.output
 
 
 @pytest.mark.ai_generated
 def test_cli_issues_dump_calls_helper(tmp_path: pathlib.Path) -> None:
-    """dandicompute issues dump delegates to dump_issues and reports output."""
+    """dandicompute issues dump delegates to QueueState.dump_issues and reports output."""
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
     dandiset_dir = tmp_path / "dandiset"
     dandiset_dir.mkdir()
 
     runner = CliRunner()
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.dump_issues", return_value=[]) as mock_dump:
+    with (
+        mock.patch(f"{_GROUP}.QueueState.dump_issues", return_value=[]) as mock_dump,
+        mock.patch(f"{_GROUP}.dump_issues") as mock_dump_fallback,
+    ):
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "issues",
-                "dump",
-                "--directory",
-                str(dandiset_dir),
-                "--queue",
-                str(queue_dir),
-            ],
+            ["issues", "dump", "--directory", str(dandiset_dir), "--queue", str(queue_dir)],
         )
 
     assert result.exit_code == 0, result.output
     mock_dump.assert_called_once_with(dandiset_directory=dandiset_dir, queue_directory=queue_dir)
+    mock_dump_fallback.assert_not_called()
     assert "Wrote issue dump" in result.output
 
 
 @pytest.mark.ai_generated
 def test_cli_issues_summarize_calls_helper(tmp_path: pathlib.Path) -> None:
-    """dandicompute issues summarize delegates to summarize_issues and reports output."""
+    """dandicompute issues summarize delegates to QueueState.summarize_issues and reports output."""
     queue_dir = tmp_path / "queue"
     queue_dir.mkdir()
     dandiset_dir = tmp_path / "dandiset"
     dandiset_dir.mkdir()
 
     runner = CliRunner()
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.summarize_issues", return_value={}) as mock_summarize:
+    with (
+        mock.patch(f"{_GROUP}.QueueState.summarize_issues", return_value={}) as mock_summarize,
+        mock.patch(f"{_GROUP}.summarize_issues") as mock_summarize_fallback,
+    ):
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "issues",
-                "summarize",
-                "--directory",
-                str(dandiset_dir),
-                "--queue",
-                str(queue_dir),
-            ],
+            ["issues", "summarize", "--directory", str(dandiset_dir), "--queue", str(queue_dir)],
         )
 
     assert result.exit_code == 0, result.output
     mock_summarize.assert_called_once_with(dandiset_directory=dandiset_dir, queue_directory=queue_dir)
+    mock_summarize_fallback.assert_not_called()
     assert "Wrote issue summary" in result.output
 
 
@@ -316,23 +307,16 @@ def test_cli_queue_process_requires_processing_directory(tmp_path: pathlib.Path)
 
 @pytest.mark.ai_generated
 def test_cli_queue_process_passes_processing_directory(tmp_path: pathlib.Path) -> None:
-    """dandicompute queue process forwards --processing to process_queue."""
+    """dandicompute queue process forwards --processing to QueueState.process_queue."""
     queue_dir = _make_queue_dir(tmp_path)
     processing_dir = tmp_path / "processing"
     processing_dir.mkdir()
     runner = CliRunner()
 
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.process_queue") as mock_process:
+    with mock.patch(f"{_GROUP}.QueueState.process_queue") as mock_process:
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "process",
-                "--queue",
-                str(queue_dir),
-                "--processing",
-                str(processing_dir),
-            ],
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir)],
             env={"DANDI_API_KEY": "test-key", "DANDI_DEVEL": "1"},
         )
 
@@ -348,25 +332,16 @@ def test_cli_queue_process_passes_processing_directory(tmp_path: pathlib.Path) -
 
 @pytest.mark.ai_generated
 def test_cli_queue_process_passes_max_concurrent_aind_jobs(tmp_path: pathlib.Path) -> None:
-    """dandicompute queue process forwards --max to process_queue."""
+    """dandicompute queue process forwards --max to QueueState.process_queue."""
     queue_dir = _make_queue_dir(tmp_path)
     processing_dir = tmp_path / "processing"
     processing_dir.mkdir()
     runner = CliRunner()
 
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.process_queue") as mock_process:
+    with mock.patch(f"{_GROUP}.QueueState.process_queue") as mock_process:
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "process",
-                "--queue",
-                str(queue_dir),
-                "--processing",
-                str(processing_dir),
-                "--max",
-                "4",
-            ],
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir), "--max", "4"],
             env={"DANDI_API_KEY": "test-key", "DANDI_DEVEL": "1"},
         )
 
@@ -382,24 +357,16 @@ def test_cli_queue_process_passes_max_concurrent_aind_jobs(tmp_path: pathlib.Pat
 
 @pytest.mark.ai_generated
 def test_cli_queue_process_passes_test_flag(tmp_path: pathlib.Path) -> None:
-    """dandicompute queue process forwards --test to process_queue."""
+    """dandicompute queue process forwards --test to QueueState.process_queue."""
     queue_dir = _make_queue_dir(tmp_path)
     processing_dir = tmp_path / "processing"
     processing_dir.mkdir()
     runner = CliRunner()
 
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.process_queue") as mock_process:
+    with mock.patch(f"{_GROUP}.QueueState.process_queue") as mock_process:
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "process",
-                "--queue",
-                str(queue_dir),
-                "--processing",
-                str(processing_dir),
-                "--test",
-            ],
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir), "--test"],
             env={"DANDI_API_KEY": "test-key", "DANDI_DEVEL": "1"},
         )
 
@@ -421,17 +388,10 @@ def test_cli_queue_process_reports_when_no_jobs_waiting(tmp_path: pathlib.Path) 
     processing_dir.mkdir()
     runner = CliRunner()
 
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.process_queue", return_value="no-pending"):
+    with mock.patch(f"{_GROUP}.QueueState.process_queue", return_value="no-pending"):
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "process",
-                "--queue",
-                str(queue_dir),
-                "--processing",
-                str(processing_dir),
-            ],
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir)],
             env={"DANDI_API_KEY": "test-key", "DANDI_DEVEL": "1"},
         )
 
@@ -449,14 +409,7 @@ def test_cli_queue_process_requires_dandi_devel(tmp_path: pathlib.Path) -> None:
 
     result = runner.invoke(
         _dandicompute_group,
-        [
-            "queue",
-            "process",
-            "--queue",
-            str(queue_dir),
-            "--processing",
-            str(processing_dir),
-        ],
+        ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir)],
         env={"DANDI_API_KEY": "test-key"},
     )
 
@@ -466,25 +419,16 @@ def test_cli_queue_process_requires_dandi_devel(tmp_path: pathlib.Path) -> None:
 
 @pytest.mark.ai_generated
 def test_cli_queue_process_passes_jitter_seconds(tmp_path: pathlib.Path) -> None:
-    """dandicompute queue process forwards --jitter to process_queue."""
+    """dandicompute queue process forwards --jitter to QueueState.process_queue."""
     queue_dir = _make_queue_dir(tmp_path)
     processing_dir = tmp_path / "processing"
     processing_dir.mkdir()
     runner = CliRunner()
 
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.process_queue") as mock_process:
+    with mock.patch(f"{_GROUP}.QueueState.process_queue") as mock_process:
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "process",
-                "--queue",
-                str(queue_dir),
-                "--processing",
-                str(processing_dir),
-                "--jitter",
-                "120.0",
-            ],
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir), "--jitter", "120.0"],
             env={"DANDI_API_KEY": "test-key", "DANDI_DEVEL": "1"},
         )
 
@@ -512,9 +456,7 @@ def test_cli_queue_pending_reports_and_sets_exit_code(
     """dandicompute queue pending prints the boolean and exits 0 when pending, 1 otherwise."""
     runner = CliRunner()
 
-    with mock.patch(
-        "dandi_compute_code._cli._dandicompute_group.has_pending_jobs", return_value=pending
-    ) as mock_has_pending:
+    with mock.patch(f"{_GROUP}.QueueState.has_pending_jobs", return_value=pending) as mock_has_pending:
         result = runner.invoke(_dandicompute_group, ["queue", "pending"])
 
     assert result.exit_code == expected_exit_code, result.output
@@ -527,7 +469,7 @@ def test_cli_queue_pending_silent_suppresses_output(tmp_path: pathlib.Path) -> N
     """dandicompute queue pending --silent still sets the exit code but prints nothing."""
     runner = CliRunner()
 
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.has_pending_jobs", return_value=False):
+    with mock.patch(f"{_GROUP}.QueueState.has_pending_jobs", return_value=False):
         result = runner.invoke(_dandicompute_group, ["queue", "pending", "--silent"])
 
     assert result.exit_code == 1, result.output
@@ -536,25 +478,16 @@ def test_cli_queue_pending_silent_suppresses_output(tmp_path: pathlib.Path) -> N
 
 @pytest.mark.ai_generated
 def test_cli_queue_process_passes_zero_jitter(tmp_path: pathlib.Path) -> None:
-    """dandicompute queue process forwards --jitter 0 to process_queue."""
+    """dandicompute queue process forwards --jitter 0 to QueueState.process_queue."""
     queue_dir = _make_queue_dir(tmp_path)
     processing_dir = tmp_path / "processing"
     processing_dir.mkdir()
     runner = CliRunner()
 
-    with mock.patch("dandi_compute_code._cli._dandicompute_group.process_queue") as mock_process:
+    with mock.patch(f"{_GROUP}.QueueState.process_queue") as mock_process:
         result = runner.invoke(
             _dandicompute_group,
-            [
-                "queue",
-                "process",
-                "--queue",
-                str(queue_dir),
-                "--processing",
-                str(processing_dir),
-                "--jitter",
-                "0",
-            ],
+            ["queue", "process", "--queue", str(queue_dir), "--processing", str(processing_dir), "--jitter", "0"],
             env={"DANDI_API_KEY": "test-key", "DANDI_DEVEL": "1"},
         )
 

--- a/tests/dandi_compute_code/queue/test_cli_queue_refresh.py
+++ b/tests/dandi_compute_code/queue/test_cli_queue_refresh.py
@@ -36,7 +36,7 @@ def test_cli_queue_refresh_with_dandiset_directory(tmp_path: pathlib.Path) -> No
     runner = CliRunner()
     with (
         mock.patch(
-            "dandi_compute_code.queue._write_queue_state.load_assets_jsonld_metadata",
+            "dandi_compute_code.queue._queue_state.load_assets_jsonld_metadata",
             return_value=AssetsJsonldMetadata(
                 content_id_to_asset={},
                 path_to_asset_metadata={
@@ -50,7 +50,7 @@ def test_cli_queue_refresh_with_dandiset_directory(tmp_path: pathlib.Path) -> No
             ),
         ),
         mock.patch(
-            "dandi_compute_code.queue._write_queue_state._load_upstream_assets_jsonld_metadata",
+            "dandi_compute_code.queue._queue_utils._load_upstream_assets_jsonld_metadata",
             return_value=AssetsJsonldMetadata(
                 content_id_to_asset={},
                 path_to_asset_metadata={


### PR DESCRIPTION
## Summary

Implements a soft-rollout failsafe mechanism for migrating queue CLI commands from free-function implementations to the new `QueueState` object-oriented model. Commands now attempt the OOP path first, with automatic fallback to current behavior on any failure, while recording failures to a log for investigation.

## Key Changes

- **New failsafe module** (`_oop_failsafe.py`): Provides `run_with_oop_failsafe()` wrapper that:
  - Attempts the new OOP code path first
  - Records any failures to a structured JSONL log file (with traceback, error type, and timestamp)
  - Falls back to current free-function behavior transparently
  - Supports kill-switch via `DANDICOMPUTE_DISABLE_OOP` environment variable to bypass OOP entirely during rollout

- **CLI command updates**: Wrapped all queue-related commands with the failsafe:
  - `queue process`, `queue prepare`, `queue refresh`, `queue clean`, `queue stats`, `queue pending`
  - `issues dump`, `issues summarize`
  - `prepare aind --test`
  - Each command now delegates to `QueueState` methods while maintaining fallback to original implementations

- **Comprehensive test coverage** (`test_cli_oop_failsafe.py`):
  - Verifies OOP failures trigger fallback and logging
  - Confirms successful OOP paths skip fallback and logging
  - Tests kill-switch behavior
  - Validates log appending across multiple invocations
  - Ensures each command records its own label in failure logs

- **Test infrastructure updates**:
  - Updated existing CLI tests to mock `QueueState` methods instead of free functions
  - Added fixture to redirect OOP failsafe logs to temporary directories during testing
  - Clarified test documentation about OOP/fallback separation

## Implementation Details

- Failsafe log defaults to `~/.dandicompute/oop_failsafe.jsonl` but respects `DANDICOMPUTE_OOP_FAILSAFE_LOG` override
- Kill-switch recognizes truthy values: `1`, `true`, `yes`, `on` (case-insensitive)
- Failures are logged with full traceback for debugging without blocking user operations
- All wrapped commands maintain identical external behavior regardless of which path executes

https://claude.ai/code/session_015oFBf7tQbGRXiQvNCRoKuG