### PR TITLE
Switch from YAML to JSON-LD for DANDI assets metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.46"
+version = "0.3.47"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/queue/_queue_state.py
+++ b/src/dandi_compute_code/queue/_queue_state.py
@@ -520,7 +520,13 @@ class QueueState:
         return params_key
 
     @classmethod
-    def from_assets(cls, *, dandiset_id: str = _JOB_CAPSULES_DANDISET_ID) -> QueueState:
+    def from_assets_jsonld(
+        cls,
+        file_path: pathlib.Path | None = None,
+        /,
+        *,
+        dandiset_id: str = _JOB_CAPSULES_DANDISET_ID,
+    ) -> QueueState:
         """
         Build a queue state from a Dandiset's DANDI ``assets.jsonld`` metadata.
 
@@ -529,11 +535,45 @@ class QueueState:
         ``content_id`` / ``asset_size_bytes`` resolved from the upstream source
         Dandiset's ``assets.jsonld``.
 
-        :param dandiset_id: The Dandiset whose ``assets.jsonld`` is read. Defaults to
-            the job capsules Dandiset (``001697``).
+        When *file_path* is ``None`` the ``assets.jsonld`` file is fetched from
+        the DANDI S3 bucket over the network.  When a path is provided the file
+        is read locally; the file should be a JSON file whose content is a list
+        of asset dicts with ``path``, ``contentSize``, ``dateModified``, and
+        ``contentUrl`` fields (matching the ``assets.jsonld`` layout from
+        DANDI).  The ``.jsonld`` file is preferred over its ``assets.yaml``
+        counterpart at the same S3 location because JSON parsing is many
+        times faster than YAML for identical content.
+
+        :param file_path: Optional path to a local assets JSON-LD file.  Pass
+            ``None`` to fetch from the network.
+        :type file_path: pathlib.Path, optional
+        :param dandiset_id: The Dandiset whose ``assets.jsonld`` is read when
+            fetching from the network. Defaults to the job capsules Dandiset
+            (``001697``). Ignored when *file_path* is provided.
         :type dandiset_id: str
         """
-        local_metadata = load_assets_jsonld_metadata(dandiset_id=dandiset_id)
+        if file_path is None:
+            local_metadata = load_assets_jsonld_metadata(dandiset_id=dandiset_id)
+        else:
+            raw = json.loads(file_path.read_text())
+            if not isinstance(raw, list):
+                raise ValueError(f"Expected a JSON array in {file_path}, got {type(raw).__name__}")
+            content_id_to_asset: dict[str, dict] = {}
+            path_to_asset_metadata: dict[str, AssetMetadata] = {}
+            for asset in raw:
+                if not isinstance(asset, dict):
+                    continue
+                try:
+                    content_id, metadata = _build_asset_metadata(asset)
+                except ValueError:
+                    continue
+                content_id_to_asset[content_id] = asset
+                path_to_asset_metadata[metadata.path] = metadata
+            local_metadata = AssetsJsonldMetadata(
+                content_id_to_asset=content_id_to_asset,
+                path_to_asset_metadata=path_to_asset_metadata,
+            )
+
         collection = _collect_attempts(local_metadata)
         upstream_cache = _UpstreamMetadataCache()
         records = _finalize_attempt_records(collection=collection, upstream_cache=upstream_cache)
@@ -552,7 +592,7 @@ class QueueState:
         Write a queue state file from DANDI ``assets.jsonld`` metadata.
 
         Validates ``queue_config.json`` under *queue_directory*, builds the state via
-        :meth:`from_assets`, and writes it to ``queue_directory/state_file_name``.
+        :meth:`from_assets_jsonld`, and writes it to ``queue_directory/state_file_name``.
 
         :param queue_directory: Path to the queue root directory.
         :type queue_directory: pathlib.Path
@@ -564,7 +604,7 @@ class QueueState:
         :raises ValueError: If the queue configuration fails LinkML validation.
         """
         _load_queue_config(queue_directory=queue_directory)
-        state = cls.from_assets(dandiset_id=dandiset_id)
+        state = cls.from_assets_jsonld(dandiset_id=dandiset_id)
         state.to_file(queue_directory / state_file_name)
 
     @classmethod
@@ -936,53 +976,6 @@ class QueueState:
             raise FileNotFoundError(message)
         stripped_lines = [line.strip() for line in file_path.read_text().splitlines()]
         entries = [JobEntry.from_dict(json.loads(line)) for line in stripped_lines if line]
-        return cls(entries=entries)
-
-    @classmethod
-    def from_assets_jsonld(cls, file_path: pathlib.Path | None = None, /) -> QueueState:
-        """
-        Build from DANDI assets metadata.
-
-        When *file_path* is ``None`` the metadata is fetched from the DANDI
-        S3 bucket over the network.  When a path is provided the file is read
-        locally; the file should be a JSON file whose content is a list of
-        asset dicts with ``path``, ``contentSize``, ``dateModified``, and
-        ``contentUrl`` fields (matching the ``assets.jsonld`` layout from
-        DANDI).  The ``.jsonld`` file is preferred over its ``assets.yaml``
-        counterpart at the same S3 location because JSON parsing is many
-        times faster than YAML for identical content.
-
-        :param file_path: Optional path to a local assets JSON-LD file.  Pass
-            ``None`` to fetch from the network.
-        :type file_path: pathlib.Path, optional
-        """
-        if file_path is None:
-            local_metadata = load_assets_jsonld_metadata()
-        else:
-            raw = json.loads(file_path.read_text())
-            if not isinstance(raw, list):
-                raise ValueError(f"Expected a JSON array in {file_path}, got {type(raw).__name__}")
-            content_id_to_asset: dict[str, dict] = {}
-            path_to_asset_metadata: dict[str, AssetMetadata] = {}
-            for asset in raw:
-                if not isinstance(asset, dict):
-                    continue
-                try:
-                    content_id, metadata = _build_asset_metadata(asset)
-                except ValueError:
-                    continue
-                content_id_to_asset[content_id] = asset
-                path_to_asset_metadata[metadata.path] = metadata
-            local_metadata = AssetsJsonldMetadata(
-                content_id_to_asset=content_id_to_asset,
-                path_to_asset_metadata=path_to_asset_metadata,
-            )
-
-        collection = _collect_attempts(local_metadata)
-        upstream_cache = _UpstreamMetadataCache()
-        records = _finalize_attempt_records(collection=collection, upstream_cache=upstream_cache)
-        records.sort(key=_sort_key)
-        entries = [JobEntry.from_dict(record) for record in records]
         return cls(entries=entries)
 
     def to_file(self, file_path: pathlib.Path, /) -> None:

--- a/src/dandi_compute_code/queue/_queue_state.py
+++ b/src/dandi_compute_code/queue/_queue_state.py
@@ -565,7 +565,8 @@ class QueueState:
                 continue
             try:
                 content_id, metadata = _build_asset_metadata(asset)
-            except ValueError:
+            except ValueError as exception:
+                _log.debug("Skipping malformed asset in %s: %s", file_path, exception)
                 continue
             content_id_to_asset[content_id] = asset
             path_to_asset_metadata[metadata.path] = metadata

--- a/src/dandi_compute_code/queue/_queue_state.py
+++ b/src/dandi_compute_code/queue/_queue_state.py
@@ -520,64 +520,75 @@ class QueueState:
         return params_key
 
     @classmethod
-    def from_assets_jsonld(
-        cls,
-        *,
-        file_path: pathlib.Path | None = None,
-        dandiset_id: str = _JOB_CAPSULES_DANDISET_ID,
-    ) -> QueueState:
+    def from_metadata(cls, metadata: AssetsJsonldMetadata, /) -> QueueState:
         """
-        Build a queue state from a Dandiset's DANDI ``assets.jsonld`` metadata.
+        Build a queue state from indexed DANDI assets metadata.
 
         Each entry represents one attempt capsule inferred from the
         ``derivatives/dandiset-*/.../pipeline-*/..._attempt-*`` path structure, with
         ``content_id`` / ``asset_size_bytes`` resolved from the upstream source
         Dandiset's ``assets.jsonld``.
 
-        When *file_path* is ``None`` the ``assets.jsonld`` file is fetched from
-        the DANDI S3 bucket over the network.  When a path is provided the file
-        is read locally; the file should be a JSON file whose content is a list
-        of asset dicts with ``path``, ``contentSize``, ``dateModified``, and
-        ``contentUrl`` fields (matching the ``assets.jsonld`` layout from
-        DANDI).  The ``.jsonld`` file is preferred over its ``assets.yaml``
-        counterpart at the same S3 location because JSON parsing is many
-        times faster than YAML for identical content.
-
-        :param file_path: Optional path to a local assets JSON-LD file.  Pass
-            ``None`` to fetch from the network.
-        :type file_path: pathlib.Path, optional
-        :param dandiset_id: The Dandiset whose ``assets.jsonld`` is read when
-            fetching from the network. Defaults to the job capsules Dandiset
-            (``001697``). Ignored when *file_path* is provided.
-        :type dandiset_id: str
+        :param metadata: Indexed assets metadata, as produced by
+            :meth:`from_jsonld` or :meth:`from_dandi`.
+        :type metadata: AssetsJsonldMetadata
         """
-        if file_path is None:
-            local_metadata = load_assets_jsonld_metadata(dandiset_id=dandiset_id)
-        else:
-            raw = json.loads(file_path.read_text())
-            if not isinstance(raw, list):
-                raise ValueError(f"Expected a JSON array in {file_path}, got {type(raw).__name__}")
-            content_id_to_asset: dict[str, dict] = {}
-            path_to_asset_metadata: dict[str, AssetMetadata] = {}
-            for asset in raw:
-                if not isinstance(asset, dict):
-                    continue
-                try:
-                    content_id, metadata = _build_asset_metadata(asset)
-                except ValueError:
-                    continue
-                content_id_to_asset[content_id] = asset
-                path_to_asset_metadata[metadata.path] = metadata
-            local_metadata = AssetsJsonldMetadata(
-                content_id_to_asset=content_id_to_asset,
-                path_to_asset_metadata=path_to_asset_metadata,
-            )
-
-        collection = _collect_attempts(local_metadata)
+        collection = _collect_attempts(metadata)
         upstream_cache = _UpstreamMetadataCache()
         records = _finalize_attempt_records(collection=collection, upstream_cache=upstream_cache)
         records.sort(key=_sort_key)
         return cls(entries=[JobEntry.from_dict(record) for record in records])
+
+    @classmethod
+    def from_jsonld(cls, *, file_path: pathlib.Path) -> QueueState:
+        """
+        Build a queue state from a local DANDI ``assets.jsonld`` file.
+
+        The file should be a JSON file whose content is a list of asset dicts
+        with ``path``, ``contentSize``, ``dateModified``, and ``contentUrl``
+        fields (matching the ``assets.jsonld`` layout from DANDI).  The
+        ``.jsonld`` file is preferred over its ``assets.yaml`` counterpart at
+        the same S3 location because JSON parsing is many times faster than
+        YAML for identical content.
+
+        :param file_path: Path to a local assets JSON-LD file.
+        :type file_path: pathlib.Path
+        :raises ValueError: If the file content is not a JSON array.
+        """
+        raw = json.loads(file_path.read_text())
+        if not isinstance(raw, list):
+            raise ValueError(f"Expected a JSON array in {file_path}, got {type(raw).__name__}")
+        content_id_to_asset: dict[str, dict] = {}
+        path_to_asset_metadata: dict[str, AssetMetadata] = {}
+        for asset in raw:
+            if not isinstance(asset, dict):
+                continue
+            try:
+                content_id, metadata = _build_asset_metadata(asset)
+            except ValueError:
+                continue
+            content_id_to_asset[content_id] = asset
+            path_to_asset_metadata[metadata.path] = metadata
+        return cls.from_metadata(
+            AssetsJsonldMetadata(
+                content_id_to_asset=content_id_to_asset,
+                path_to_asset_metadata=path_to_asset_metadata,
+            )
+        )
+
+    @classmethod
+    def from_dandi(cls, *, dandiset_id: str = _JOB_CAPSULES_DANDISET_ID) -> QueueState:
+        """
+        Build a queue state from a Dandiset's remote ``assets.jsonld`` metadata.
+
+        Fetches ``assets.jsonld`` for *dandiset_id* from the DANDI S3 bucket
+        over the network.
+
+        :param dandiset_id: The Dandiset whose ``assets.jsonld`` is read.
+            Defaults to the job capsules Dandiset (``001697``).
+        :type dandiset_id: str
+        """
+        return cls.from_metadata(load_assets_jsonld_metadata(dandiset_id=dandiset_id))
 
     @classmethod
     def write_state(
@@ -591,7 +602,7 @@ class QueueState:
         Write a queue state file from DANDI ``assets.jsonld`` metadata.
 
         Validates ``queue_config.json`` under *queue_directory*, builds the state via
-        :meth:`from_assets_jsonld`, and writes it to ``queue_directory/state_file_name``.
+        :meth:`from_dandi`, and writes it to ``queue_directory/state_file_name``.
 
         :param queue_directory: Path to the queue root directory.
         :type queue_directory: pathlib.Path
@@ -603,7 +614,7 @@ class QueueState:
         :raises ValueError: If the queue configuration fails LinkML validation.
         """
         _load_queue_config(queue_directory=queue_directory)
-        state = cls.from_assets_jsonld(dandiset_id=dandiset_id)
+        state = cls.from_dandi(dandiset_id=dandiset_id)
         state.to_file(queue_directory / state_file_name)
 
     @classmethod

--- a/src/dandi_compute_code/queue/_queue_state.py
+++ b/src/dandi_compute_code/queue/_queue_state.py
@@ -522,9 +522,8 @@ class QueueState:
     @classmethod
     def from_assets_jsonld(
         cls,
-        file_path: pathlib.Path | None = None,
-        /,
         *,
+        file_path: pathlib.Path | None = None,
         dandiset_id: str = _JOB_CAPSULES_DANDISET_ID,
     ) -> QueueState:
         """

--- a/src/dandi_compute_code/queue/_queue_state.py
+++ b/src/dandi_compute_code/queue/_queue_state.py
@@ -30,8 +30,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Literal
 
-import yaml
-
 from ._globals import _AIND_EPHYS_PARAMS_REGISTRY
 from ._job_info import JobInfo
 from ._queue_utils import (
@@ -941,26 +939,29 @@ class QueueState:
         return cls(entries=entries)
 
     @classmethod
-    def from_assets_yaml(cls, file_path: pathlib.Path | None = None, /) -> QueueState:
+    def from_assets_jsonld(cls, file_path: pathlib.Path | None = None, /) -> QueueState:
         """
         Build from DANDI assets metadata.
 
         When *file_path* is ``None`` the metadata is fetched from the DANDI
         S3 bucket over the network.  When a path is provided the file is read
-        locally; the file should be a YAML file whose content is a list of
+        locally; the file should be a JSON file whose content is a list of
         asset dicts with ``path``, ``contentSize``, ``dateModified``, and
-        ``contentUrl`` fields (matching the ``assets.yaml`` layout from DANDI).
+        ``contentUrl`` fields (matching the ``assets.jsonld`` layout from
+        DANDI).  The ``.jsonld`` file is preferred over its ``assets.yaml``
+        counterpart at the same S3 location because JSON parsing is many
+        times faster than YAML for identical content.
 
-        :param file_path: Optional path to a local assets YAML file.  Pass
+        :param file_path: Optional path to a local assets JSON-LD file.  Pass
             ``None`` to fetch from the network.
         :type file_path: pathlib.Path, optional
         """
         if file_path is None:
             local_metadata = load_assets_jsonld_metadata()
         else:
-            raw = yaml.safe_load(file_path.read_text())
+            raw = json.loads(file_path.read_text())
             if not isinstance(raw, list):
-                raise ValueError(f"Expected a YAML list in {file_path}, got {type(raw).__name__}")
+                raise ValueError(f"Expected a JSON array in {file_path}, got {type(raw).__name__}")
             content_id_to_asset: dict[str, dict] = {}
             path_to_asset_metadata: dict[str, AssetMetadata] = {}
             for asset in raw:

--- a/tests/dandi_compute_code/queue/model/conftest.py
+++ b/tests/dandi_compute_code/queue/model/conftest.py
@@ -39,7 +39,7 @@ def mock_dandi_assets_metadata() -> Iterator[None]:
     """
     Default the DANDI ``assets.jsonld`` loaders to empty so no test hits the network.
 
-    ``QueueState.write_state`` (and ``from_assets_jsonld`` / ``pending_code_dirs``) fetch
+    ``QueueState.write_state`` (and ``from_dandi`` / ``pending_code_dirs``) fetch
     assets metadata from the DANDI archive via the ``_queue_state`` binding. This
     guard makes that return empty by default. Tests that need specific metadata
     override these with their own ``mock.patch``.

--- a/tests/dandi_compute_code/queue/model/conftest.py
+++ b/tests/dandi_compute_code/queue/model/conftest.py
@@ -39,7 +39,7 @@ def mock_dandi_assets_metadata() -> Iterator[None]:
     """
     Default the DANDI ``assets.jsonld`` loaders to empty so no test hits the network.
 
-    ``QueueState.write_state`` (and ``from_assets`` / ``pending_code_dirs``) fetch
+    ``QueueState.write_state`` (and ``from_assets_jsonld`` / ``pending_code_dirs``) fetch
     assets metadata from the DANDI archive via the ``_queue_state`` binding. This
     guard makes that return empty by default. Tests that need specific metadata
     override these with their own ``mock.patch``.


### PR DESCRIPTION
## Summary
This PR updates the queue state initialization to use JSON-LD format instead of YAML for loading DANDI assets metadata, improving parsing performance and aligning with DANDI's preferred format.

## Key Changes
- Renamed `from_assets_yaml()` method to `from_assets_jsonld()` to reflect the new format
- Replaced `yaml.safe_load()` with `json.loads()` for parsing asset metadata files
- Removed the `yaml` import dependency from the module
- Updated error messages and docstrings to reference JSON arrays instead of YAML lists
- Enhanced documentation to explain that JSON-LD parsing is significantly faster than YAML for identical content

## Implementation Details
- The method now expects JSON-LD formatted files (matching DANDI's `assets.jsonld` layout) instead of YAML
- When `file_path` is `None`, metadata is still fetched from the network via `load_assets_jsonld_metadata()`
- The asset metadata structure remains unchanged; only the file format and parsing method have been updated
- Error handling updated to provide appropriate feedback for JSON parsing failures

https://claude.ai/code/session_01DB6WeTNUBecRYpkP4pfddW