### PR TITLE
Use timestamped log files in failsafe log directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.47"
+version = "0.3.48"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/_cli/_oop_failsafe.py
+++ b/src/dandi_compute_code/_cli/_oop_failsafe.py
@@ -2,7 +2,8 @@
 Soft-rollout failsafe for the new ``QueueState`` OOP model.
 
 Each queue-related CLI command first attempts the new OOP code path. If that
-path raises for any reason, the failure is recorded to a failsafe log file (so
+path raises for any reason, the failure is recorded to a timestamped file in the
+failsafe log directory (so
 it can be investigated and fixed later) and the command falls back to the
 current free-function runtime behavior. This keeps the rollout safe: a defect in
 the new model never regresses a user-facing command, but every divergence is
@@ -22,14 +23,14 @@ _log = logging.getLogger(__name__)
 
 _ResultT = TypeVar("_ResultT")
 
-#: Environment variable that overrides the failsafe log location.
+#: Environment variable that overrides the failsafe log directory.
 _OOP_FAILSAFE_LOG_ENV_VAR = "DANDICOMPUTE_OOP_FAILSAFE_LOG"
 
 #: Environment variable kill-switch that disables the new OOP path entirely.
 _OOP_DISABLE_ENV_VAR = "DANDICOMPUTE_DISABLE_OOP"
 
-#: Default failsafe log file used when the override variable is unset.
-_DEFAULT_OOP_FAILSAFE_LOG = pathlib.Path.home() / ".dandicompute" / "oop_failsafe.jsonl"
+#: Default failsafe log directory used when the override variable is unset.
+_DEFAULT_OOP_FAILSAFE_LOG_DIRECTORY = pathlib.Path.home() / ".dandicompute" / "oop_failsafe"
 
 #: Values of the kill-switch variable that count as "disabled".
 _TRUTHY_DISABLE_VALUES = frozenset({"1", "true", "yes", "on"})
@@ -40,27 +41,30 @@ def _oop_path_is_disabled() -> bool:
     return os.environ.get(_OOP_DISABLE_ENV_VAR, "").strip().lower() in _TRUTHY_DISABLE_VALUES
 
 
-def _resolve_oop_failsafe_log_path() -> pathlib.Path:
-    """Resolve the failsafe log path, honoring the override environment variable."""
+def _resolve_oop_failsafe_log_directory() -> pathlib.Path:
+    """Resolve the failsafe log directory, honoring the override environment variable."""
     override = os.environ.get(_OOP_FAILSAFE_LOG_ENV_VAR, "").strip()
-    log_path = pathlib.Path(override) if override else _DEFAULT_OOP_FAILSAFE_LOG
-    return log_path
+    log_directory = pathlib.Path(override) if override else _DEFAULT_OOP_FAILSAFE_LOG_DIRECTORY
+    return log_directory
 
 
 def _record_oop_failure(*, command: str, error: BaseException) -> None:
-    """Append a structured record of an OOP-path failure to the failsafe log file."""
+    """Append a structured record of an OOP-path failure to a timestamped failsafe log file."""
+    logged_at = datetime.datetime.now(datetime.timezone.utc)
     formatted_traceback = "".join(traceback.format_exception(type(error), error, error.__traceback__))
     record = {
-        "logged_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "logged_at": logged_at.isoformat(),
         "command": command,
         "error_type": type(error).__name__,
         "error_message": str(error),
         "traceback": formatted_traceback,
     }
 
-    log_path = _resolve_oop_failsafe_log_path()
+    # Second-level resolution keeps names filesystem-safe; same-second failures append to the same file.
+    log_directory = _resolve_oop_failsafe_log_directory()
+    log_path = log_directory / f"oop_failsafe_{logged_at.strftime('%Y-%m-%dT%H-%M-%SZ')}.jsonl"
     try:
-        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_directory.mkdir(parents=True, exist_ok=True)
         with log_path.open(mode="a") as log_stream:
             log_stream.write(json.dumps(record) + "\n")
     except OSError as log_error:
@@ -77,7 +81,9 @@ def run_with_oop_failsafe(
     Attempt the new OOP ``QueueState`` code path, falling back to current behavior.
 
     The *oop_path* callable is attempted first. If it raises any exception, the
-    failure is recorded to the failsafe log file for later investigation and
+    failure is recorded to a timestamped file in the failsafe log directory
+    (``DANDICOMPUTE_OOP_FAILSAFE_LOG``, defaulting to
+    ``~/.dandicompute/oop_failsafe/``) for later investigation and
     *fallback_path* is invoked to preserve the current runtime behavior. The
     result of whichever path completes is returned.
 

--- a/tests/dandi_compute_code/_cli/test_cli_oop_failsafe.py
+++ b/tests/dandi_compute_code/_cli/test_cli_oop_failsafe.py
@@ -2,12 +2,14 @@
 Tests for the soft-rollout failsafe shared by the queue CLI commands.
 
 Each command first attempts the new ``QueueState`` OOP model and, on any failure,
-records the failure to a log file and falls back to the current free-function
-behavior. These tests drive that path through the public CLI surface.
+records the failure to a timestamped log file inside the failsafe log directory
+and falls back to the current free-function behavior. These tests drive that
+path through the public CLI surface.
 """
 
 import json
 import pathlib
+import re
 from unittest import mock
 
 import pytest
@@ -17,11 +19,22 @@ from dandi_compute_code._cli import _dandicompute_group
 
 _GROUP = "dandi_compute_code._cli._dandicompute_group"
 
+_LOG_FILE_NAME_PATTERN = re.compile(r"^oop_failsafe_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.jsonl$")
+
 
 @pytest.fixture
-def failsafe_log(tmp_path: pathlib.Path) -> pathlib.Path:
-    """A temporary failsafe log path wired through the override environment variable."""
-    return tmp_path / "oop_failsafe.jsonl"
+def failsafe_log_directory(tmp_path: pathlib.Path) -> pathlib.Path:
+    """A temporary failsafe log directory wired through the override environment variable."""
+    return tmp_path / "oop_failsafe_logs"
+
+
+def _read_failsafe_records(log_directory: pathlib.Path) -> list[dict]:
+    """Read all failure records from every timestamped log file in the failsafe directory."""
+    records = []
+    for log_path in sorted(log_directory.glob("*.jsonl")):
+        assert _LOG_FILE_NAME_PATTERN.match(log_path.name), log_path.name
+        records.extend(json.loads(line) for line in log_path.read_text().splitlines() if line.strip())
+    return records
 
 
 def _make_queue_dir(tmp_path: pathlib.Path) -> pathlib.Path:
@@ -34,7 +47,7 @@ def _make_queue_dir(tmp_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.mark.ai_generated
-def test_oop_failure_falls_back_and_logs(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
+def test_oop_failure_falls_back_and_logs(tmp_path: pathlib.Path, failsafe_log_directory: pathlib.Path) -> None:
     """When the OOP path raises, the command logs the failure and runs the fallback."""
     queue_dir = _make_queue_dir(tmp_path)
     processing_dir = tmp_path / "processing"
@@ -51,7 +64,7 @@ def test_oop_failure_falls_back_and_logs(tmp_path: pathlib.Path, failsafe_log: p
             env={
                 "DANDI_API_KEY": "test-key",
                 "DANDI_DEVEL": "1",
-                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log),
+                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log_directory),
             },
         )
 
@@ -65,8 +78,8 @@ def test_oop_failure_falls_back_and_logs(tmp_path: pathlib.Path, failsafe_log: p
         test=False,
     )
 
-    assert failsafe_log.exists()
-    records = [json.loads(line) for line in failsafe_log.read_text().splitlines() if line.strip()]
+    assert failsafe_log_directory.is_dir()
+    records = _read_failsafe_records(failsafe_log_directory)
     assert len(records) == 1
     assert records[0]["command"] == "queue process"
     assert records[0]["error_type"] == "RuntimeError"
@@ -76,7 +89,9 @@ def test_oop_failure_falls_back_and_logs(tmp_path: pathlib.Path, failsafe_log: p
 
 
 @pytest.mark.ai_generated
-def test_oop_success_skips_fallback_and_does_not_log(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
+def test_oop_success_skips_fallback_and_does_not_log(
+    tmp_path: pathlib.Path, failsafe_log_directory: pathlib.Path
+) -> None:
     """When the OOP path succeeds, the fallback is not used and nothing is logged."""
     queue_dir = _make_queue_dir(tmp_path)
     processing_dir = tmp_path / "processing"
@@ -93,20 +108,20 @@ def test_oop_success_skips_fallback_and_does_not_log(tmp_path: pathlib.Path, fai
             env={
                 "DANDI_API_KEY": "test-key",
                 "DANDI_DEVEL": "1",
-                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log),
+                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log_directory),
             },
         )
 
     assert result.exit_code == 0, result.output
     mock_oop.assert_called_once()
     mock_fallback.assert_not_called()
-    assert not failsafe_log.exists()
+    assert not failsafe_log_directory.exists()
 
 
 @pytest.mark.ai_generated
 @pytest.mark.parametrize("disable_value", ["1", "true", "yes", "on", "TRUE"])
 def test_kill_switch_skips_oop_and_runs_fallback(
-    tmp_path: pathlib.Path, failsafe_log: pathlib.Path, disable_value: str
+    tmp_path: pathlib.Path, failsafe_log_directory: pathlib.Path, disable_value: str
 ) -> None:
     """The kill-switch env var bypasses the OOP path without attempting or logging it."""
     queue_dir = _make_queue_dir(tmp_path)
@@ -125,18 +140,18 @@ def test_kill_switch_skips_oop_and_runs_fallback(
                 "DANDI_API_KEY": "test-key",
                 "DANDI_DEVEL": "1",
                 "DANDICOMPUTE_DISABLE_OOP": disable_value,
-                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log),
+                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log_directory),
             },
         )
 
     assert result.exit_code == 0, result.output
     mock_oop.assert_not_called()
     mock_fallback.assert_called_once()
-    assert not failsafe_log.exists()
+    assert not failsafe_log_directory.exists()
 
 
 @pytest.mark.ai_generated
-def test_kill_switch_unset_still_attempts_oop(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
+def test_kill_switch_unset_still_attempts_oop(tmp_path: pathlib.Path, failsafe_log_directory: pathlib.Path) -> None:
     """A blank or absent kill-switch leaves the OOP path as the primary route."""
     queue_dir = _make_queue_dir(tmp_path)
     processing_dir = tmp_path / "processing"
@@ -154,7 +169,7 @@ def test_kill_switch_unset_still_attempts_oop(tmp_path: pathlib.Path, failsafe_l
                 "DANDI_API_KEY": "test-key",
                 "DANDI_DEVEL": "1",
                 "DANDICOMPUTE_DISABLE_OOP": "",
-                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log),
+                "DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log_directory),
             },
         )
 
@@ -164,10 +179,12 @@ def test_kill_switch_unset_still_attempts_oop(tmp_path: pathlib.Path, failsafe_l
 
 
 @pytest.mark.ai_generated
-def test_failure_log_appends_across_invocations(tmp_path: pathlib.Path, failsafe_log: pathlib.Path) -> None:
-    """Repeated OOP failures append, leaving an investigable record per invocation."""
+def test_failure_log_accumulates_across_invocations(
+    tmp_path: pathlib.Path, failsafe_log_directory: pathlib.Path
+) -> None:
+    """Repeated OOP failures accumulate, leaving an investigable record per invocation."""
     runner = CliRunner()
-    env = {"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log)}
+    env = {"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log_directory)}
 
     for _ in range(2):
         with (
@@ -177,7 +194,7 @@ def test_failure_log_appends_across_invocations(tmp_path: pathlib.Path, failsafe
             result = runner.invoke(_dandicompute_group, ["queue", "pending"], env=env)
         assert result.exit_code == 0, result.output
 
-    records = [json.loads(line) for line in failsafe_log.read_text().splitlines() if line.strip()]
+    records = _read_failsafe_records(failsafe_log_directory)
     assert len(records) == 2
     assert all(record["command"] == "queue pending" for record in records)
     assert all(record["error_type"] == "ValueError" for record in records)
@@ -200,7 +217,7 @@ def test_failure_log_appends_across_invocations(tmp_path: pathlib.Path, failsafe
 )
 def test_each_command_records_its_own_label(
     tmp_path: pathlib.Path,
-    failsafe_log: pathlib.Path,
+    failsafe_log_directory: pathlib.Path,
     command: str,
     oop_target: str,
     fallback_target: str,
@@ -226,11 +243,11 @@ def test_each_command_records_its_own_label(
         result = runner.invoke(
             _dandicompute_group,
             args_by_command[command],
-            env={"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log)},
+            env={"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(failsafe_log_directory)},
         )
 
     assert result.exit_code in (0, 1), result.output
     mock_fallback.assert_called_once()
-    records = [json.loads(line) for line in failsafe_log.read_text().splitlines() if line.strip()]
+    records = _read_failsafe_records(failsafe_log_directory)
     assert len(records) == 1
     assert records[0]["command"] == expected_command_label

--- a/tests/dandi_compute_code/queue/conftest.py
+++ b/tests/dandi_compute_code/queue/conftest.py
@@ -60,9 +60,9 @@ def mock_dandi_assets_metadata() -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def redirect_oop_failsafe_log(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
-    """Redirect the OOP-failsafe log to a temporary file so tests never write under ``$HOME``."""
-    log_path = tmp_path_factory.mktemp("oop_failsafe") / "oop_failsafe.jsonl"
-    with mock.patch.dict(os.environ, {"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(log_path)}):
+    """Redirect the OOP-failsafe log directory to a temporary one so tests never write under ``$HOME``."""
+    log_directory = tmp_path_factory.mktemp("oop_failsafe")
+    with mock.patch.dict(os.environ, {"DANDICOMPUTE_OOP_FAILSAFE_LOG": str(log_directory)}):
         yield
 
 


### PR DESCRIPTION
## Summary
Changed the OOP failsafe logging mechanism from writing to a single log file to writing to timestamped log files within a log directory. This allows multiple failures to be tracked separately while maintaining a single investigation point.

## Key Changes
- **Log storage structure**: Changed from a single `oop_failsafe.jsonl` file to a directory containing timestamped log files named `oop_failsafe_YYYY-MM-DDTHH-MM-SSZ.jsonl`
  - Failures occurring in the same second append to the same file
  - Failures in different seconds get separate files for better organization
  
- **Configuration**: Updated the default failsafe log location from `~/.dandicompute/oop_failsafe.jsonl` to `~/.dandicompute/oop_failsafe/` (a directory)

- **API updates**:
  - Renamed `_resolve_oop_failsafe_log_path()` to `_resolve_oop_failsafe_log_directory()`
  - Renamed `_DEFAULT_OOP_FAILSAFE_LOG` to `_DEFAULT_OOP_FAILSAFE_LOG_DIRECTORY`
  - Updated environment variable documentation to reflect directory semantics

- **Test updates**:
  - Renamed fixture from `failsafe_log` to `failsafe_log_directory`
  - Added `_read_failsafe_records()` helper to read records from all timestamped log files
  - Added regex pattern validation for timestamped log file names
  - Updated all test assertions to work with the directory-based structure

## Implementation Details
- The timestamp format (`%Y-%m-%dT%H-%M-%SZ`) is filesystem-safe and ISO 8601-compliant
- Second-level granularity ensures same-second failures append to the same file while maintaining separation across invocations
- The directory structure is created on-demand when the first failure is recorded
- All existing failure record content and format remains unchanged

https://claude.ai/code/session_01Bf964JAjCQZQg3YBTznDTh