### PR TITLE
Switch content ID mapping from gzip JSON to JSON Lines format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = ["src/dandi_compute_code"]
 
 [project]
 name = "dandi-compute-code"
-version = "0.3.48"
+version = "0.3.49"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_compute_code/aind_ephys_pipeline/_prepare_job.py
+++ b/src/dandi_compute_code/aind_ephys_pipeline/_prepare_job.py
@@ -1,5 +1,4 @@
 import contextlib
-import gzip
 import hashlib
 import importlib.metadata
 import io
@@ -200,11 +199,15 @@ def prepare_aind_ephys_job(
 
     dandi_compute_dir = pathlib.Path("/orcd/data/dandi/001/dandi-compute")
     content_id_to_usage_dandiset_path_url = (
-        "https://raw.githubusercontent.com/dandi-cache/content-id-to-usage-dandiset-path/min/"
-        "derivatives/content_id_to_usage_dandiset_path.min.json.gz"
+        "https://raw.githubusercontent.com/dandi-cache/content-id-to-usage-dandiset-path/derivatives/"
+        "derivatives/content_id_to_usage_dandiset_path.jsonl"
     )
     with urllib.request.urlopen(url=content_id_to_usage_dandiset_path_url) as response:
-        content_id_to_usage_dandiset_path = json.loads(gzip.decompress(response.read()))
+        decoded = response.read().decode()
+    content_id_to_usage_dandiset_path = {}
+    for line in decoded.splitlines():
+        if line.strip():
+            content_id_to_usage_dandiset_path.update(json.loads(line))
 
     if content_id not in content_id_to_usage_dandiset_path:
         message = (

--- a/src/dandi_compute_code/aind_ephys_pipeline/_prepare_job.py
+++ b/src/dandi_compute_code/aind_ephys_pipeline/_prepare_job.py
@@ -204,10 +204,12 @@ def prepare_aind_ephys_job(
     )
     with urllib.request.urlopen(url=content_id_to_usage_dandiset_path_url) as response:
         decoded = response.read().decode()
-    content_id_to_usage_dandiset_path = {}
-    for line in decoded.splitlines():
-        if line.strip():
-            content_id_to_usage_dandiset_path.update(json.loads(line))
+    content_id_to_usage_dandiset_path = {
+        content_id_key: dandiset_path
+        for line in decoded.splitlines()
+        if line.strip()
+        for content_id_key, dandiset_path in json.loads(line).items()
+    }
 
     if content_id not in content_id_to_usage_dandiset_path:
         message = (

--- a/src/dandi_compute_code/dandiset/_globals.py
+++ b/src/dandi_compute_code/dandiset/_globals.py
@@ -10,8 +10,8 @@ _JOB_CAPSULES_DANDISET_ID = "001697"
 _FAILED_RUNS_ARCHIVE_DANDISET_ID = "001873"
 _SANDBOX_API_URL = "https://api.sandbox.dandiarchive.org/api"
 _CONTENT_ID_TO_USAGE_DANDISET_PATH_URL = (
-    "https://raw.githubusercontent.com/dandi-cache/content-id-to-usage-dandiset-path/min/"
-    "derivatives/content_id_to_usage_dandiset_path.min.json.gz"
+    "https://raw.githubusercontent.com/dandi-cache/content-id-to-usage-dandiset-path/derivatives/"
+    "derivatives/content_id_to_usage_dandiset_path.jsonl"
 )
 _ASSETS_JSONLD_URL_TEMPLATE = "https://dandiarchive.s3.amazonaws.com/dandisets/{dandiset_id}/draft/assets.jsonld"
 _ASSETS_JSONLD_URL = _ASSETS_JSONLD_URL_TEMPLATE.format(dandiset_id=_JOB_CAPSULES_DANDISET_ID)

--- a/src/dandi_compute_code/dandiset/_load_content_id_to_usage_dandiset_path.py
+++ b/src/dandi_compute_code/dandiset/_load_content_id_to_usage_dandiset_path.py
@@ -23,11 +23,12 @@ def _load_content_id_to_usage_dandiset_path() -> dict[str, dict[str, str]]:
     try:
         with urllib.request.urlopen(url=_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL) as response:
             decoded = response.read().decode()
-        content_id_to_usage_dandiset_path: dict[str, dict[str, str]] = {}
-        for line in decoded.splitlines():
-            if line.strip():
-                content_id_to_usage_dandiset_path.update(json.loads(line))
-        return content_id_to_usage_dandiset_path
+        return {
+            content_id: dandiset_path
+            for line in decoded.splitlines()
+            if line.strip()
+            for content_id, dandiset_path in json.loads(line).items()
+        }
     except Exception as exception:
         message = (
             "Unable to load content-id-to-usage-dandiset-path mapping from " f"{_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL}"

--- a/src/dandi_compute_code/dandiset/_load_content_id_to_usage_dandiset_path.py
+++ b/src/dandi_compute_code/dandiset/_load_content_id_to_usage_dandiset_path.py
@@ -1,5 +1,4 @@
 import functools
-import gzip
 import json
 import urllib.request
 
@@ -11,6 +10,10 @@ def _load_content_id_to_usage_dandiset_path() -> dict[str, dict[str, str]]:
     """
     Load the content ID to usage Dandiset path mapping.
 
+    The remote cache is a JSON Lines file where each line is a single-entry
+    ``{content_id: {dandiset_id: path}}`` object; the lines are merged into one
+    mapping.
+
     Raises
     ------
     RuntimeError
@@ -19,7 +22,12 @@ def _load_content_id_to_usage_dandiset_path() -> dict[str, dict[str, str]]:
     """
     try:
         with urllib.request.urlopen(url=_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL) as response:
-            return json.loads(gzip.decompress(response.read()))
+            decoded = response.read().decode()
+        content_id_to_usage_dandiset_path: dict[str, dict[str, str]] = {}
+        for line in decoded.splitlines():
+            if line.strip():
+                content_id_to_usage_dandiset_path.update(json.loads(line))
+        return content_id_to_usage_dandiset_path
     except Exception as exception:
         message = (
             "Unable to load content-id-to-usage-dandiset-path mapping from " f"{_CONTENT_ID_TO_USAGE_DANDISET_PATH_URL}"

--- a/tests/dandi_compute_code/aind_ephys_pipeline/test_prepare_job.py
+++ b/tests/dandi_compute_code/aind_ephys_pipeline/test_prepare_job.py
@@ -5,7 +5,6 @@ Tests focus on BIDS entity parsing from Dandiset path components, which is the
 logic that resolves the ``sub-`` label used in the output directory hierarchy.
 """
 
-import gzip
 import importlib.metadata
 import json
 import os
@@ -24,8 +23,12 @@ _FAKE_COMMIT_HASH = "a" * 40
 
 
 def _make_urlopen_mock(mapping: dict) -> mock.MagicMock:
-    """Build an ``urllib.request.urlopen`` mock that returns a gzip-compressed JSON mapping."""
-    payload = gzip.compress(json.dumps(mapping).encode())
+    """Build an ``urllib.request.urlopen`` mock returning the mapping as JSON Lines.
+
+    Each content ID becomes its own single-entry ``{content_id: {...}}`` line,
+    matching the remote content-id-to-usage-dandiset-path cache format.
+    """
+    payload = "\n".join(json.dumps({content_id: value}) for content_id, value in mapping.items()).encode()
     response = mock.MagicMock()
     response.read.return_value = payload
     response.__enter__ = lambda s: s


### PR DESCRIPTION
## Summary
This PR updates the codebase to handle the content ID to usage Dandiset path mapping in JSON Lines format instead of gzip-compressed JSON. This change aligns with a format update in the remote cache repository.

## Key Changes
- **Removed gzip dependency**: Eliminated `import gzip` statements from three files since the remote cache is no longer gzip-compressed
- **Updated URL references**: Changed the remote cache URL from `min/derivatives/content_id_to_usage_dandiset_path.min.json.gz` to `derivatives/content_id_to_usage_dandiset_path.jsonl` in both the globals configuration and inline usage
- **Implemented JSON Lines parsing**: Replaced single `json.loads(gzip.decompress(...))` calls with line-by-line parsing that:
  - Decodes the response as UTF-8 text
  - Iterates through each line (skipping empty lines)
  - Merges individual single-entry JSON objects into a unified mapping dictionary
- **Updated test mock**: Modified the test helper to generate JSON Lines format (one JSON object per line) instead of gzip-compressed JSON

## Implementation Details
The new parsing approach handles the JSON Lines format where each line contains a single-entry `{content_id: {dandiset_id: path}}` object. These are merged sequentially into the final mapping using `dict.update()`, maintaining the same logical behavior while supporting the new format.

https://claude.ai/code/session_01JJdWwgHHhu3CNoMBFz8buV