### PR TITLE
Fix invalid JSON and stale MD5 in registered_params.json

### DIFF
--- a/src/dandi_compute_code/aind_ephys_pipeline/registries/registered_params.json
+++ b/src/dandi_compute_code/aind_ephys_pipeline/registries/registered_params.json
@@ -41,12 +41,12 @@
   },
   "deterministic-v1.2.4": {
     "path": "name-original_version-1+2+4.json",
-    "md5": "53903329f81a8ac4a137200458100807",
+    "md5": "4e89ec786dc28fe28dda5a8cf5d9ad3a",
     "description": "Same as the `name-original_version-1+2+2.json`, but all the proportion of bad channels to not skip is raised to 1 (no skipping)."
-  }
+  },
   "default": {
     "path": "name-original_version-1+2+4.json",
-    "md5": "53903329f81a8ac4a137200458100807",
+    "md5": "4e89ec786dc28fe28dda5a8cf5d9ad3a",
     "description": "The current recommended default parameter set."
   }
 }


### PR DESCRIPTION
## Summary
- Fixes the CI failures on #308 (`Tests / run (ubuntu-latest, 3.13)`)
- The new `deterministic-v1.2.4` entry added in #308 was missing a trailing comma after its closing brace, which broke JSON parsing for every consumer of `registered_params.json`
- The recorded `md5` for `name-original_version-1+2+4.json` (used by both `deterministic-v1.2.4` and `default`) didn't match the actual file contents, causing an `MD5 mismatch` `ValueError` once the JSON parsed correctly

## Test plan
- [x] `json.load` succeeds on `registered_params.json`
- [x] Full test suite passes locally: `301 passed`

---
_Generated by [Claude Code](https://claude.ai/code/session_017PgEuL1xTWPRQJZLrngtcS)_